### PR TITLE
Fix/add stack description, Initialize secret with valid JSON, Configure DynamoDB tables to be removed on stack deletion

### DIFF
--- a/lib/my-amazon-q-slack-bot-stack.ts
+++ b/lib/my-amazon-q-slack-bot-stack.ts
@@ -31,8 +31,13 @@ export class MyAmazonQSlackBotStack extends cdk.Stack {
 
     const vpc = new Vpc(this, `${props.stackName}-VPC`);
 
+    const initialSecretContent = JSON.stringify({
+      SlackSigningSecret: '<Replace with Signing Secret>',
+      SlackBotUserOAuthToken: '<Replace with Bot User OAuth Token>'
+    });
     const slackSecret = new Secret(this, `${props.stackName}-Secret`, {
-      secretName: `${props.stackName}-Secret`
+      secretName: `${props.stackName}-Secret`,
+      secretStringValue: cdk.SecretValue.unsafePlainText(initialSecretContent)
     });
 
     const dynamoCache = new Table(this, `${props.stackName}-DynamoCache`, {
@@ -41,7 +46,8 @@ export class MyAmazonQSlackBotStack extends cdk.Stack {
         name: 'channel',
         type: AttributeType.STRING
       },
-      timeToLiveAttribute: 'expireAt'
+      timeToLiveAttribute: 'expireAt',
+      removalPolicy: cdk.RemovalPolicy.DESTROY
     });
 
     const messageMetadata = new Table(this, `${props.stackName}-MessageMetadata`, {
@@ -50,7 +56,8 @@ export class MyAmazonQSlackBotStack extends cdk.Stack {
         name: 'messageId',
         type: AttributeType.STRING
       },
-      timeToLiveAttribute: 'expireAt'
+      timeToLiveAttribute: 'expireAt',
+      removalPolicy: cdk.RemovalPolicy.DESTROY
     });
 
     [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Add Stack Description (with version read from package.json file) to CDK stack constructor, for visibility of deployed project and version from CloudFormation.

2. Configure DynamoDB tables to be removed on stack deletion

3. Initialize secret with valid JSON containing placeholders.. 
    a) syntax more obvious to users editing the secret for the first time, and 
    b) error message thrown by the Lambda more clear if user forgets to edit the initial secret value (it current throws a 'invalid JSON' error - better to throw a slack auth error).  
    Initial value now looks like this:
    
![image](https://github.com/aws-samples/amazon-q-slack-gateway/assets/10953374/73627b03-1150-45f3-8c24-26245662e9d3)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
