### PR TITLE
add error details to slack message when chat api errors

### DIFF
--- a/src/functions/slack-event-handler.ts
+++ b/src/functions/slack-event-handler.ts
@@ -164,6 +164,7 @@ export const handler = async (
   );
 
   const channelMetadata = await getChannelMetadata(channelKey, dependencies, slackEventsEnv);
+  logger.debug(`ChannelKey: ${channelKey}, Cached channel metadata: ${JSON.stringify(channelMetadata)} `)
 
   const context = {
     conversationId: channelMetadata?.conversationId,
@@ -264,9 +265,10 @@ export const handler = async (
   ]);
 
   if (output instanceof Error) {
-    const blocks = [getMarkdownBlock(ERROR_MSG)];
+    const errMsgWithDetails = `${ERROR_MSG}\n_${output.message}_`
+    const blocks = [getMarkdownBlock(errMsgWithDetails)];
 
-    await dependencies.updateSlackMessage(slackEventsEnv, slackMessage, ERROR_MSG, blocks);
+    await dependencies.updateSlackMessage(slackEventsEnv, slackMessage, errMsgWithDetails, blocks);
 
     return {
       statusCode: 200,

--- a/src/helpers/amazon-q/amazon-q-helpers.ts
+++ b/src/helpers/amazon-q/amazon-q-helpers.ts
@@ -37,7 +37,11 @@ export const chat = async (
     return response;
   } catch (error) {
     logger.error(`Caught Exception: ${JSON.stringify(error)}`);
-    return new Error(`Caught Exception: ${JSON.stringify(error)}`);
+    if (error instanceof Error) {
+      return new Error(error.message);
+    } else {
+      return new Error(`${JSON.stringify(error)}`);
+    }
   }
 };
 

--- a/src/helpers/slack/slack-helpers.ts
+++ b/src/helpers/slack/slack-helpers.ts
@@ -12,7 +12,7 @@ const logger = makeLogger('slack-helpers');
 
 let secretManagerClient: SecretsManager | null = null;
 
-export const ERROR_MSG = 'An error has occurred. Our team has been notified.';
+export const ERROR_MSG = '*_Processing error_*';
 const getSecretManagerClient = (env: SlackInteractionsEnv | SlackEventsEnv) => {
   if (secretManagerClient === null) {
     secretManagerClient = new SecretsManager({ region: env.REGION });


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*

Amazon Q ChatSync api exceptions now provide more informative error message to the user..  For example:
![image](https://github.com/aws-samples/amazon-q-slack-gateway/assets/10953374/83ec0b9d-d50e-4a2a-b739-00b4f0b2a8d0)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
