### PR TITLE
Messages with attachments have undefined Team id - breaks follow-up questions on attachments..

### DIFF
--- a/src/functions/slack-event-handler.ts
+++ b/src/functions/slack-event-handler.ts
@@ -155,9 +155,11 @@ export const handler = async (
     };
   }
 
+  // 
+
   const channelKey = getChannelKey(
     body.event.type,
-    body.event.team,
+    body.team_id,
     body.event.channel,
     body.event.event_ts,
     body.event.thread_ts


### PR DESCRIPTION
Messages with attachments have undefined Team id, resulting in channelKey undefined:<channelid>.. Breaks followup questions on attachments..

*Issue #, if available:*
n/a

*Description of changes:*

use body_team_id instead of body.event_team_id since the latter is not defined in all messages (messages with attachments)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
