### PR TITLE
Fix/file upload error message

### DIFF
--- a/src/functions/slack-event-handler.ts
+++ b/src/functions/slack-event-handler.ts
@@ -287,6 +287,22 @@ export const handler = async (
     };
   }
 
+  if (!isEmpty(output.failedAttachments)) {
+    // Append error message for failed attachments to systemMessage
+    const fileErrorMessages = [];
+    for (const f of output.failedAttachments) {
+      if (f.status === 'FAILED') {
+        logger.debug(`Failed attachment: File ${f.name} - ${f.error.errorMessage}`);
+        fileErrorMessages.push(` \u2022 ${f.name}: ${f.error.errorMessage}`);
+      }
+    }
+    if (!isEmpty(fileErrorMessages)) {
+      output.systemMessage = `${
+        output.systemMessage
+      }\n\n*_Failed attachments:_*\n${fileErrorMessages.join('\n')}`;
+    }
+  }
+
   const blocks = [
     ...dependencies.getResponseAsBlocks(output),
     ...dependencies.getFeedbackBlocks(output)

--- a/src/helpers/amazon-q/amazon-q-client.ts
+++ b/src/helpers/amazon-q/amazon-q-client.ts
@@ -16,6 +16,7 @@ export interface AmazonQResponse extends ChatResponse {
   systemMessageId: string;
   userMessageId: string;
   sourceAttributions?: SourceAttribution[];
+  failedAttachments?: AttachmentOutput[];
 }
 
 export interface SourceAttribution {
@@ -30,6 +31,17 @@ export interface SourceAttribution {
 export interface TextSegment {
   beginOffset?: number;
   endOffset?: number;
+}
+
+export interface AttachmentOutput {
+  name: string;
+  status: string;
+  error: AttachmentErrorDetail;
+}
+
+export interface AttachmentErrorDetail {
+  errorMessage: string;
+  errorCode: string;
 }
 
 export const initAmazonQSDK = () => {


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*

If any or all file attachments fail, the app now lists the failed files with corresponding error message, eg:
![image](https://github.com/aws-samples/amazon-q-slack-gateway/assets/10953374/893daf58-6d31-4379-ac2d-2159a75d7864)

If only a subset of files succeeded, the ones that failed are listed, so user knows that only some were used in the response..
![image](https://github.com/aws-samples/amazon-q-slack-gateway/assets/10953374/30bfa9dc-aca4-47fe-9e06-bae45aa4bfc2)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
