### PR TITLE
Enable option for stack deployment using CloudFormation with no dependency on dev shell, cdk, etc.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 node_modules
 package.lock.json
-bin
 dist
+cdk.out
+build

--- a/.eslintrc
+++ b/.eslintrc
@@ -10,5 +10,8 @@
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:prettier/recommended"
-  ]
+  ],
+  "env": {
+    "node": true
+  }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -13,5 +13,13 @@
   ],
   "env": {
     "node": true
-  }
+  },
+  "overrides": [
+    {
+      "files": ["*.js"],
+      "rules": {
+        "@typescript-eslint/no-var-requires": "off"
+      }
+    }
+  ]
 }

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Important:** Bug reports submitted here should relate specifically to the open source sample amazon-q-slack-gateway project. Do not submit bugs related to the Amazon Q service itself.  
+If your issue relates to Amazon Q setup, user provisioning, document ingestion, accuracy, or other aspects of the service, then first check the Amazon Q documentation, and then reproduce the problem using the Amazon Q console web experience before engaging AWS support directly. Thank you.  
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-*.js
 !jest.config.js
 *.d.ts
 node_modules

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 node_modules
 package.lock.json
-bin
 dist
+cdk.out
+build

--- a/README.md
+++ b/README.md
@@ -36,36 +36,32 @@ Follow the instructions below to deploy the project to your own AWS account and 
 
 ### Prerequisites
 
-You need to have an AWS account and an IAM Role/User with permissions to create and manage the necessary resources and components for this application.*If you do not have an AWS account, please see [How do I create and activate a new Amazon Web Services account?](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/)*
+You need to have an AWS account and an IAM Role/User with permissions to create and manage the necessary resources and components for this application. *(If you do not have an AWS account, please see [How do I create and activate a new Amazon Web Services account?](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/))*
 
 You also need to have an existing, working Amazon Q application. If you haven't set one up yet, see [Creating an Amazon Q application](https://docs.aws.amazon.com/amazonq/latest/business-use-dg/create-app.html)
 
-### 1. Deploy a new amazon-q-slack-gateway stack
+### 1. Deploy the stack
 
-We've made this really easy by providing pre-built AWS CloudFormation templates that deploy everything you need in your AWS account 
+We've made this easy by providing pre-built AWS CloudFormation templates that deploy everything you need in your AWS account.
+
+If you are a developer, and you want to build, deploy and/or publish the solution from code, we've made that easy too! See []()
 
 1. Log into the [AWS console](https://console.aws.amazon.com/) if you are not already.
 2. Choose one of the **Launch Stack** buttons below for your desired AWS region to open the AWS CloudFormation console and create a new stack.
-3. On the CloudFormation `Create Stack` page, click `Next`
 4. Enter the following parameters:
-    1. `Stack Name`: Name your stack, e.g. AMAZON-Q-SLACK-GATEWAY.
+    1. `Stack Name`: Name your App, e.g. AMAZON-Q-SLACK-GATEWAY.
     2. `AmazonQAppId`: Your existing Amazon Q Application ID (copy from Amazon Q console). 
     3. `AmazonQRegion`: Choose the region where you created your Amazon Q Application.
     4. `AmazonQUserId`: (Optional) Amazon Q User ID email address (leave empty to use Slack users email as user Id)
     5. `ContextDaysToLive`: Just leave this as the default (90 days)
 
-#### <u>N. Virginia (us-east-1)</u>
-Launch Stack | Template URL
---- | ---
-[![Launch Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.us-east-1.amazonaws.com/aws-ml-blog-us-east-1/artifacts/amazon-q-slack-gateway/AmazonQSlackGateway.json&stackName=AMAZON-Q-SLACK-GATEWAY) | https://s3.us-east-1.amazonaws.com/aws-ml-blog-us-east-1/artifacts/amazon-q-slack-gateway/AmazonQSlackGateway.json
-
-#### <u>Oregon (us-west-2)</u>
-Launch Stack | Template URL
---- | ---
-[![Launch Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://us-west-2.console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://s3.us-west-2.amazonaws.com/aws-ml-blog-us-west-2/artifacts/amazon-q-slack-gateway/AmazonQSlackGateway.json&stackName=AMAZON-Q-SLACK-GATEWAY) | https://s3.us-west-2.amazonaws.com/aws-ml-blog-us-west-2/artifacts/amazon-q-slack-gateway/AmazonQSlackGateway.json
+Region | Easy Deploy Button | Template URL - use to upgrade existing stack to a new release
+--- | --- | ---
+N. Virginia (us-east-1) | [![Launch Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.us-east-1.amazonaws.com/aws-ml-blog-us-east-1/artifacts/amazon-q-slack-gateway/AmazonQSlackGateway.json&stackName=AMAZON-Q-SLACK-GATEWAY) | https://s3.us-east-1.amazonaws.com/aws-ml-blog-us-east-1/artifacts/amazon-q-slack-gateway/AmazonQSlackGateway.json
+Oregon (us-west-2) | [![Launch Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://us-west-2.console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://s3.us-west-2.amazonaws.com/aws-ml-blog-us-west-2/artifacts/amazon-q-slack-gateway/AmazonQSlackGateway.json&stackName=AMAZON-Q-SLACK-GATEWAY) | https://s3.us-west-2.amazonaws.com/aws-ml-blog-us-west-2/artifacts/amazon-q-slack-gateway/AmazonQSlackGateway.json
 
 
-When your CloudFormation stack status is CREATE_COMPLETE, choose the **Outputs** tab
+When your CloudFormation stack status is CREATE_COMPLETE, choose the **Outputs** tab, and keep it open - you'll need it below.
 
 
 ### 2. Configure your Slack application
@@ -74,7 +70,7 @@ When your CloudFormation stack status is CREATE_COMPLETE, choose the **Outputs**
 
 Now you can create your app in Slack!
 
-1. Create a Slack app: https://api.slack.com/apps from the generated manifest - copy / paste from `SlackAppManifest` stack output.
+1. Create a Slack app: https://api.slack.com/apps from the generated manifest - copy / paste from the stack output: `SlackAppManifest`.
 2. Go to `App Home`, scroll down to the section `Show Tabs` and enable `Message Tab` then check the box `Allow users to send Slash commands and messages from the messages tab` - This is a required step to enable your user to send messages to your app
 
 #### 2.3 Add your app in your workspace
@@ -88,7 +84,7 @@ Let's now add your app into your workspace, this is required to generate the `Bo
 4. In the right pane, click on "Open in App Directory"
 5. Click "Open in Slack"
 
-### 4. Configure your Secrets in AWS
+### 3. Configure your Secrets in AWS
 
 Let's configure your Slack secrets in order to (1) verify the signature of each request, (2) post on behalf of your bot
 
@@ -98,16 +94,11 @@ Let's configure your Slack secrets in order to (1) verify the signature of each 
 > Please create an issue (or, better yet, a pull request!) in this repo if you want this feature added to a future version.
 
 1. Login to your AWS console
-2. In your AWS account go to Secret manager, using the URL shown in `SlackSecretConsoleUrl` stack output.
+2. In your AWS account go to Secret manager, using the URL shown in the stack output: `SlackSecretConsoleUrl`.
 3. Choose `Retrieve secret value`
 4. Choose `Edit`
-5. Replace secret value with the following JSON and replace with the value of `Signing Secret` and `Bot User OAuth Token`, you will find those values in the Slack application configuration under `Basic Information` and `OAuth & Permissions`:
-```
-{
-  "SlackSigningSecret": "VALUE_HERE",
-  "SlackBotUserOAuthToken": "VALUE_HERE"
-}
- ```
+5. Replace the value of `Signing Secret` and `Bot User OAuth Token`, you will find those values in the Slack application configuration under `Basic Information` and `OAuth & Permissions`:
+
 
 ### Say hello
 > Time to say Hi!

--- a/README.md
+++ b/README.md
@@ -34,41 +34,50 @@ Follow the instructions below to deploy the project to your own AWS account and 
 
 ## Deploy the solution
 
-### 1. Dependencies
+### Prerequisites
 
-You need to have the following packages installed on your computer to build and deploy the project.
-
-1. bash shell (Linux, MacOS, Windows-WSL)
-2. node and npm: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm 
-3. tsc (typescript): `npm install -g typescript`
-4. esbuild: `npm i -g esbuild`
-5. jq: https://jqlang.github.io/jq/download/
-6. aws (AWS CLI): https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html 
-7. cdk (AWS CDK): https://docs.aws.amazon.com/cdk/v2/guide/cli.html
+You need to have an AWS account and an IAM Role/User with permissions to create and manage the necessary resources and components for this application.*If you do not have an AWS account, please see [How do I create and activate a new Amazon Web Services account?](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/)*
 
 You also need to have an existing, working Amazon Q application. If you haven't set one up yet, see [Creating an Amazon Q application](https://docs.aws.amazon.com/amazonq/latest/business-use-dg/create-app.html)
 
-### 2. Initialize and deploy the stack
+### 1. Deploy a new amazon-q-slack-gateway stack
 
-Copy the GitHub repo to your computer. Either:
-- use the git command: git clone https://github.com/aws-samples/amazon-q-slack-gateway.git
-- OR, download and expand the ZIP file from the GitHub page: https://github.com/aws-samples/amazon-q-slack-gateway/archive/refs/heads/main.zip
+We've made this really easy by providing pre-built AWS CloudFormation templates that deploy everything you need in your AWS account 
 
-Navigate into the project root directory and, in a bash shell, run:
+1. Log into the [AWS console](https://console.aws.amazon.com/) if you are not already.
+2. Choose one of the **Launch Stack** buttons below for your desired AWS region to open the AWS CloudFormation console and create a new stack.
+3. On the CloudFormation `Create Stack` page, click `Next`
+4. Enter the following parameters:
+    1. `Stack Name`: Name your stack, e.g. AMAZON-Q-SLACK-GATEWAY.
+    2. `AmazonQAppId`: Your existing Amazon Q Application ID (copy from Amazon Q console). 
+    3. `AmazonQRegion`: Choose the region where you created your Amazon Q Application.
+    4. `AmazonQUserId`: (Optional) Amazon Q User ID email address (leave empty to use Slack users email as user Id)
+    5. `ContextDaysToLive`: Just leave this as the default (90 days)
 
-1. `./init.sh` - checks your system dependendencies for required packages (see Dependencies above), sets up your environment file, and bootstraps your cdk environment.
-2. `./deploy.sh` - runs the cdk build and deploys or updates a stack in your AWS account, creates a slack app manifest file, and outputs a link to the AWS Secrets Manager secret that you will need below.
+#### <u>N. Virginia (us-east-1)</u>
+Launch Stack | Template URL
+--- | ---
+[![Launch Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.us-east-1.amazonaws.com/aws-ml-blog-us-east-1/artifacts/amazon-q-slack-gateway/AmazonQSlackGateway.json&stackName=AMAZON-Q-SLACK-GATEWAY) | https://s3.us-east-1.amazonaws.com/aws-ml-blog-us-east-1/artifacts/amazon-q-slack-gateway/AmazonQSlackGateway.json
 
-### 3. Configure your Slack application
+#### <u>Oregon (us-west-2)</u>
+Launch Stack | Template URL
+--- | ---
+[![Launch Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://us-west-2.console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://s3.us-west-2.amazonaws.com/aws-ml-blog-us-west-2/artifacts/amazon-q-slack-gateway/AmazonQSlackGateway.json&stackName=AMAZON-Q-SLACK-GATEWAY) | https://s3.us-west-2.amazonaws.com/aws-ml-blog-us-west-2/artifacts/amazon-q-slack-gateway/AmazonQSlackGateway.json
 
-#### 3.2 Create your app
+
+When your CloudFormation stack status is CREATE_COMPLETE, choose the **Outputs** tab
+
+
+### 2. Configure your Slack application
+
+#### 2.2 Create your app
 
 Now you can create your app in Slack!
 
-1. Create a Slack app: https://api.slack.com/apps from the generated manifest `./slack-manifest-output.json` (copy / paste)
+1. Create a Slack app: https://api.slack.com/apps from the generated manifest - copy / paste from `SlackAppManifest` stack output.
 2. Go to `App Home`, scroll down to the section `Show Tabs` and enable `Message Tab` then check the box `Allow users to send Slash commands and messages from the messages tab` - This is a required step to enable your user to send messages to your app
 
-#### 3.3 Add your app in your workspace
+#### 2.3 Add your app in your workspace
 
 Let's now add your app into your workspace, this is required to generate the `Bot User OAuth Token` value that will be needed in the next step
 
@@ -89,7 +98,7 @@ Let's configure your Slack secrets in order to (1) verify the signature of each 
 > Please create an issue (or, better yet, a pull request!) in this repo if you want this feature added to a future version.
 
 1. Login to your AWS console
-2. In your AWS account go to Secret manager, using the URL that was output by the `deploy.sh` script above. 
+2. In your AWS account go to Secret manager, using the URL shown in `SlackSecretConsoleUrl` stack output.
 3. Choose `Retrieve secret value`
 4. Choose `Edit`
 5. Replace secret value with the following JSON and replace with the value of `Signing Secret` and `Bot User OAuth Token`, you will find those values in the Slack application configuration under `Basic Information` and `OAuth & Permissions`:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You also need to have an existing, working Amazon Q application. If you haven't 
 
 We've made this easy by providing pre-built AWS CloudFormation templates that deploy everything you need in your AWS account.
 
-If you are a developer, and you want to build, deploy and/or publish the solution from code, we've made that easy too! See []()
+If you are a developer, and you want to build, deploy and/or publish the solution from code, we've made that easy too! See [Developer README](./README_DEVELOPERS.md)
 
 1. Log into the [AWS console](https://console.aws.amazon.com/) if you are not already.
 2. Choose one of the **Launch Stack** buttons below for your desired AWS region to open the AWS CloudFormation console and create a new stack.

--- a/README_DEVELOPERS.md
+++ b/README_DEVELOPERS.md
@@ -1,0 +1,122 @@
+# Developer README
+
+The main README is here: [Slack gateway for Amazon Q, your business expert (preview)](./README.md)
+
+This README describes how to build the project from the source code - for developer types. You can:
+- [Deploy the solution](#deploy-the-solution)
+- [Publish the solution](#publish-the-solution)
+
+### 1. Dependencies
+
+To deploy or to publish, you need to have the following packages installed on your computer:
+
+1. bash shell (Linux, MacOS, Windows-WSL)
+2. node and npm: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm 
+3. tsc (typescript): `npm install -g typescript`
+4. esbuild: `npm i -g esbuild`
+5. jq: https://jqlang.github.io/jq/download/
+6. aws (AWS CLI): https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html 
+7. cdk (AWS CDK): https://docs.aws.amazon.com/cdk/v2/guide/cli.html
+
+Copy the GitHub repo to your computer. Either:
+- use the git command: git clone https://github.com/aws-samples/amazon-q-slack-gateway.git
+- OR, download and expand the ZIP file from the GitHub page: https://github.com/aws-samples/amazon-q-slack-gateway/archive/refs/heads/main.zip
+
+## Deploy the solution
+
+Before starting, you need to have an existing, working Amazon Q application. If you haven't set one up yet, see [Creating an Amazon Q application](https://docs.aws.amazon.com/amazonq/latest/business-use-dg/create-app.html)
+
+### 1. Initialize and deploy the stack
+
+Navigate into the project root directory and, in a bash shell, run:
+
+1. `./init.sh` - checks your system dependendencies for required packages (see Dependencies above), sets up your environment file, and bootstraps your cdk environment.
+2. `./deploy.sh` - runs the cdk build and deploys or updates a stack in your AWS account, creates a slack app manifest file, and outputs a link to the AWS Secrets Manager secret that you will need below.
+
+### 3. Configure your Slack application
+
+#### 3.2 Create your app
+
+Now you can create your app in Slack!
+
+1. Create a Slack app: https://api.slack.com/apps from the generated manifest `./slack-manifest-output.json` (copy / paste)
+2. Go to `App Home`, scroll down to the section `Show Tabs` and enable `Message Tab` then check the box `Allow users to send Slash commands and messages from the messages tab` - This is a required step to enable your user to send messages to your app
+
+#### 3.3 Add your app in your workspace
+
+Let's now add your app into your workspace, this is required to generate the `Bot User OAuth Token` value that will be needed in the next step
+
+1. Go to OAuth & Permissions (in api.slack.com) and click `Install to Workspace`, this will generate the OAuth token
+2. In Slack, go to your workspace
+2. Click on your workspace name > Settings & administration > Manage apps
+3. Click on your newly created app
+4. In the right pane, click on "Open in App Directory"
+5. Click "Open in Slack"
+
+### 4. Configure your Secrets in AWS
+
+Let's configure your Slack secrets in order to (1) verify the signature of each request, (2) post on behalf of your bot
+
+> **IMPORTANT**
+> In this example we are not enabling Slack token rotation. Enable it for a production app by implementing
+> rotation via AWS Secrets Manager. 
+> Please create an issue (or, better yet, a pull request!) in this repo if you want this feature added to a future version.
+
+1. Login to your AWS console
+2. In your AWS account go to Secret manager, using the URL that was output by the `deploy.sh` script above. 
+3. Choose `Retrieve secret value`
+4. Choose `Edit`
+5. Replace the value of `Signing Secret` and `Bot User OAuth Token`, you will find those values in the Slack application configuration under `Basic Information` and `OAuth & Permissions`:
+
+### Say hello
+> Time to say Hi!
+
+1. Go to Slack
+2. Under Apps > Manage, add your new Amazon Q app
+3. Optionally add your app to team channels
+4. In the app DM channel, say *Hello*. In a team channel, ask it for help with an @mention.
+5. Enjoy.
+
+
+## Publish the solution
+
+In our main README, you will see that we provided Easy Deploy Buttons to launch a stack using pre-built templates that we published already to an S3 bucket. 
+
+If you want to build and deploy your own template, to your own S3 bucket, so that others can easily deploy a stack using your templates, here's how.
+
+Navigate into the project root directory and, in a bash shell, run:
+
+1. `./publish.sh <cfn_bucket_basename> <cfn_prefix> <us-east-1 | us-west-2>` - this:
+  - checks your system dependendencies for required packages (see Dependencies above)
+  - bootstraps your cdk environment if needed
+  - creates a standalone CloudFormation template (that doesn't depend on CDK)
+  - publishes the template and required assets to an S3 bucket in your account called `cfn_bucket_basename-region` (it creates the bucket if it doesn't already exist)
+  - optionally add a final parameter `public` if you want to make the templates public. Note: your bucket and account must be configured not to Block Public Access using new ACLs.
+
+That's it! Just one step.
+  
+When completed, it displays the CloudFormation templates S3 URLs and 1-click URLs for launching the stack creation in CloudFormation console, e.g.:
+```
+OUTPUTS
+Template URL: https://s3.us-east-1.amazonaws.com/yourbucket-us-east-1/qslack-test/AmazonQSlackGateway.json
+CF Launch URL: https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.us-east-1.amazonaws.com/yourbucket-us-east-1/qslack-test/AmazonQSlackGateway.json&stackName=AMAZON-Q-SLACK-GATEWAY
+Done
+``````
+
+Follow the deployment directions in the main [README](./README.md), but use your own CF Launch URL instead of our pre-built templates (Launch Stack buttons). 
+
+
+## Contributing, and reporting issues
+
+We welcome your contributions to our project. Whether it's a bug report, new feature, correction, or additional
+documentation, we greatly value feedback and contributions from our community.
+
+See [CONTRIBUTING](CONTRIBUTING.md) for more information.
+
+## Security
+
+See [Security issue notifications](CONTRIBUTING.md#security-issue-notifications) for more information.
+
+## License
+
+This library is licensed under the MIT-0 License. See the [LICENSE](./LICENSE) file.

--- a/bin/convert-cfn-template.js
+++ b/bin/convert-cfn-template.js
@@ -1,7 +1,7 @@
-import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as JSZip from 'jszip';
+const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
+const fs = require('fs');
+const path = require('path');
+const JSZip = require('jszip');
 
 // Read command line arguments
 const templateName = process.argv[2];

--- a/bin/convert-cfn-template.js
+++ b/bin/convert-cfn-template.js
@@ -1,0 +1,226 @@
+const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
+const fs = require('fs');
+const path = require('path');
+const JSZip = require('jszip');
+
+// Read command line arguments
+const templateName = process.argv[2];
+const destinationBucket = process.argv[3];
+const destinationPrefix = process.argv[4];
+const awsRegion = process.argv[5];
+if (!templateName || !destinationBucket || !destinationPrefix || !awsRegion) {
+    console.error("Error: All arguments must be provided.");
+    console.error("Usage: <script> <templateName> <destinationBucket> <destinationPrefix> <awsRegion>");
+    process.exit(1);
+}
+
+const s3Client = new S3Client({ region: awsRegion });
+
+// Run cdk synth first - it creates the Lambda code assets and CF template in cdk.out 
+async function main() {
+
+    try {
+        // Read the CloudFormation template
+        const templatePath = path.join('cdk.out', `${templateName}`);
+        console.log(`Reading template from ${templatePath}...`);
+        const template = JSON.parse(fs.readFileSync(templatePath, 'utf8'));
+
+        // Identify all Lambda function assets in the template
+        console.log("Identifying Lambda function assets...");
+        const assets = identifyLambdaAssets(template);
+
+        // Zip and upload assets from cdk.out to new S3 location
+        for (let asset of assets) {
+            console.log(`Zipping and uploading asset: ${asset.key}`);
+            const zippedFilePath = await zipAsset(asset);
+            await uploadAsset(zippedFilePath, destinationBucket, destinationPrefix, asset.key);
+            fs.unlinkSync(zippedFilePath); // Clean up local zipped file
+        }
+
+        // Update template with new asset paths
+        console.log("Updating CloudFormation template with new asset paths...");
+        updateTemplateLambdaAssetPaths(template, assets, destinationBucket, destinationPrefix);
+
+        // Remove remaining CDK vestiges
+        delete template.Parameters.BootstrapVersion;
+        delete template.Rules.CheckBootstrapVersion;
+
+        // Parameterize the environment variables
+        console.log("Adding parameters to CloudFormation template...");
+        parameterizeTemplate(template, assets);
+
+        // Add slack app manifest to the Outputs
+        console.log("Adding slack manifest to CloudFormation template...");
+        addSlackAppManifestOutputToTemplate(template);
+
+        // Modify template description to differentiate from cdk deployments
+        template.Description += ' (from S3 template)'
+
+        // Copy converted template to new S3 location
+        const convertedTemplateKey = `${destinationPrefix}/${templateName}`;
+        console.log(`Uploading converted template to s3://${destinationBucket}/${convertedTemplateKey}`);
+        await s3Client.send(new PutObjectCommand({
+            Bucket: destinationBucket,
+            Key: convertedTemplateKey,
+            Body: JSON.stringify(template, null, 2)
+        }));
+
+    } catch (error) {
+        console.error('An error occurred:', error);
+        process.exit(1);
+    }
+}
+
+function identifyLambdaAssets(template) {
+    let assets = [];
+    for (let [key, value] of Object.entries(template.Resources)) {
+        if (value.Type === "AWS::Lambda::Function" && value.Properties.Code?.S3Key) {
+            console.log(`Found asset in resource ${key}`);
+            assets.push({
+                key: value.Properties.Code.S3Key,
+                resourceName: key
+            });
+        }
+    }
+    return assets;
+}
+
+async function zipAsset(asset) {
+    const assetHash = asset.key.split('.')[0]
+    const sourceDir = path.join('cdk.out', `asset.${assetHash}`);
+    const outPath = `${path.join('cdk.out', assetHash)}.zip`;
+
+    const zip = new JSZip();
+    const files = fs.readdirSync(sourceDir);
+    console.log(`Files: ${files}`)
+    files.forEach(file => {
+        const filePath = path.join(sourceDir, file);
+        const fileData = fs.readFileSync(filePath);
+        zip.file(file, fileData);
+    });
+
+    await new Promise((resolve, reject) => {
+        zip
+            .generateNodeStream({ type: 'nodebuffer', streamFiles: true })
+            .pipe(fs.createWriteStream(outPath))
+            .on('finish', resolve) // Resolve the promise on finish
+            .on('error', reject);  // Reject the promise on error
+    });
+
+    return outPath
+}
+
+async function uploadAsset(zippedFilePath, destinationBucket, destinationPrefix, originalKey) {
+    const fileStream = fs.createReadStream(zippedFilePath);
+    const destinationKey = `${destinationPrefix}/${path.basename(originalKey)}`;
+
+    console.log(`Uploading zipped asset to s3://${destinationBucket}/${destinationKey}`);
+
+    try {
+        const response = await s3Client.send(new PutObjectCommand({
+            Bucket: destinationBucket,
+            Key: destinationKey,
+            Body: fileStream
+        }));
+    } catch (error) {
+        console.error("An error occurred:", error);
+    }
+}
+
+function updateTemplateLambdaAssetPaths(template, assets, destinationBucket, destinationPrefix) {
+    for (let asset of assets) {
+        let lambdaResource = template.Resources[asset.resourceName];
+        lambdaResource.Properties.Code.S3Bucket = destinationBucket;
+        lambdaResource.Properties.Code.S3Key = `${destinationPrefix}/${path.basename(asset.key)}`;
+    }
+}
+
+function parameterizeTemplate(template, assets) {
+    template.Parameters = {
+        AmazonQUserId: {
+            Type: "String",
+            Default: "",
+            AllowedPattern: '(|^[\w.+-]+@([\w-]+\.)+[\w-]{2,6}$)',
+            Description: '(Optional) Amazon Q User ID email address (leave empty to use Slack users email as user Id)'
+        },
+        AmazonQAppId: {
+            Type: "String",
+            AllowedPattern: '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$',
+            Description: 'Existing Amazon Q Application ID (copy from Amazon Q console)'
+        },
+        AmazonQRegion: {
+            Type: "String",
+            Default: "us-east-1",
+            AllowedValues: ['us-east-1', 'us-west-2'],
+            Description: 'Amazon Q Region'
+        },
+        ContextDaysToLive: {
+            Type: "Number",
+            Default: 90,
+            MinValue: 1,
+            Description: 'Number of days to keep conversation context'
+        }
+    }
+    for (let asset of assets) {
+        let lambdaResource = template.Resources[asset.resourceName];
+        lambdaResource.Properties.Environment.Variables.AMAZON_Q_ENDPOINT = ''; // use default endpoint
+        lambdaResource.Properties.Environment.Variables.AMAZON_Q_USER_ID = { "Ref": "AmazonQUserId" };
+        lambdaResource.Properties.Environment.Variables.AMAZON_Q_APP_ID = { "Ref": "AmazonQAppId" };
+        lambdaResource.Properties.Environment.Variables.AMAZON_Q_REGION = { "Ref": "AmazonQRegion" };
+        lambdaResource.Properties.Environment.Variables.CONTEXT_DAYS_TO_LIVE = { "Ref": "ContextDaysToLive" };
+    }
+}
+
+function replaceSubstringInObject(obj, searchValue, replaceValue) {
+    for (let key in obj) {
+        if (typeof obj[key] === 'string') {
+            obj[key] = obj[key].replace(searchValue, replaceValue);
+        } else if (typeof obj[key] === 'object') {
+            replaceSubstringInObject(obj[key], searchValue, replaceValue);
+        }
+    }
+}
+
+function findOutputKey(obj, substring) {
+    let keys = Object.keys(obj).filter(key => key.includes(substring));
+    return keys[0] || null; // Return the first key or null if no match is found
+}
+
+function addSlackAppManifestOutputToTemplate(template) {
+    // Read the manifest template
+    const manifestFile = 'slack-manifest-template.json';
+    console.log(`Reading slack app manifest template from ${manifestFile}...`);
+    const manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf8'));
+    // replace token string with variable
+    replaceSubstringInObject(manifest, '!!! \[SlackBotName\] !!!', '${SlackBotName}');
+    replaceSubstringInObject(manifest, '!!! \[SlackEventHandlerApiOutput\] !!!', '${SlackEventHandlerApiOutput}');
+    replaceSubstringInObject(manifest, '!!! \[SlackInteractionHandlerApiOutput\] !!!', '${SlackInteractionHandlerApiOutput}');
+    replaceSubstringInObject(manifest, '!!! \[SlackCommandApiOutput\] !!!', '${SlackCommandApiOutput}');
+    manifestString = JSON.stringify(manifest);
+    // get values for the token variables
+    SlackBotNameValue = { "Ref": "AWS::StackName" }
+    SlackEventHandlerApiOutputKey = findOutputKey(template.Outputs, 'SlackEventHandlerApiEndpoint');
+    SlackEventHandlerApiOutputValue = template.Outputs[SlackEventHandlerApiOutputKey].Value;
+    SlackInteractionHandlerApiOutputKey = findOutputKey(template.Outputs, 'SlackInteractionHandlerApiEndpoint');
+    SlackInteractionHandlerApiOutputValue = template.Outputs[SlackInteractionHandlerApiOutputKey].Value;
+    SlackCommandApiOutputKey = findOutputKey(template.Outputs, 'SlackCommandHandlerApiEndpoint');
+    SlackCommandApiOutputOutputValue = template.Outputs[SlackCommandApiOutputKey].Value;
+    // create manifest expression using Fn::Sub
+    manifestExpression = {
+        "Fn::Sub": [
+            manifestString,
+            {
+                SlackBotName: SlackBotNameValue,
+                SlackEventHandlerApiOutput: SlackEventHandlerApiOutputValue,
+                SlackInteractionHandlerApiOutput: SlackInteractionHandlerApiOutputValue,
+                SlackCommandApiOutput: SlackCommandApiOutputOutputValue
+            }
+        ]
+    }
+    // add manifest output to template
+    template.Outputs.SlackAppManifest = {
+        Value: manifestExpression
+    };
+}
+
+main();

--- a/bin/convert-cfn-template.js
+++ b/bin/convert-cfn-template.js
@@ -219,7 +219,8 @@ function addSlackAppManifestOutputToTemplate(template) {
     }
     // add manifest output to template
     template.Outputs.SlackAppManifest = {
-        Value: manifestExpression
+        Value: manifestExpression,
+        Description: 'Slack app manifest JSON (copy/paste to create/update slack app)'
     };
 }
 

--- a/bin/convert-cfn-template.js
+++ b/bin/convert-cfn-template.js
@@ -1,7 +1,7 @@
-const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
-const fs = require('fs');
-const path = require('path');
-const JSZip = require('jszip');
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as JSZip from 'jszip';
 
 // Read command line arguments
 const templateName = process.argv[2];
@@ -9,219 +9,246 @@ const destinationBucket = process.argv[3];
 const destinationPrefix = process.argv[4];
 const awsRegion = process.argv[5];
 if (!templateName || !destinationBucket || !destinationPrefix || !awsRegion) {
-    console.error("Error: All arguments must be provided.");
-    console.error("Usage: <script> <templateName> <destinationBucket> <destinationPrefix> <awsRegion>");
-    process.exit(1);
+  console.error('Error: All arguments must be provided.');
+  console.error(
+    'Usage: <script> <templateName> <destinationBucket> <destinationPrefix> <awsRegion>'
+  );
+  process.exit(1);
 }
 
 const s3Client = new S3Client({ region: awsRegion });
 
-// Run cdk synth first - it creates the Lambda code assets and CF template in cdk.out 
+// Run cdk synth first - it creates the Lambda code assets and CF template in cdk.out
 async function main() {
+  try {
+    // Read the CloudFormation template
+    const templatePath = path.join('cdk.out', `${templateName}`);
+    console.log(`Reading template from ${templatePath}...`);
+    const template = JSON.parse(fs.readFileSync(templatePath, 'utf8'));
 
-    try {
-        // Read the CloudFormation template
-        const templatePath = path.join('cdk.out', `${templateName}`);
-        console.log(`Reading template from ${templatePath}...`);
-        const template = JSON.parse(fs.readFileSync(templatePath, 'utf8'));
+    // Identify all Lambda function assets in the template
+    console.log('Identifying Lambda function assets...');
+    const assets = identifyLambdaAssets(template);
 
-        // Identify all Lambda function assets in the template
-        console.log("Identifying Lambda function assets...");
-        const assets = identifyLambdaAssets(template);
-
-        // Zip and upload assets from cdk.out to new S3 location
-        for (let asset of assets) {
-            console.log(`Zipping and uploading asset: ${asset.key}`);
-            const zippedFilePath = await zipAsset(asset);
-            await uploadAsset(zippedFilePath, destinationBucket, destinationPrefix, asset.key);
-            fs.unlinkSync(zippedFilePath); // Clean up local zipped file
-        }
-
-        // Update template with new asset paths
-        console.log("Updating CloudFormation template with new asset paths...");
-        updateTemplateLambdaAssetPaths(template, assets, destinationBucket, destinationPrefix);
-
-        // Remove remaining CDK vestiges
-        delete template.Parameters.BootstrapVersion;
-        delete template.Rules.CheckBootstrapVersion;
-
-        // Parameterize the environment variables
-        console.log("Adding parameters to CloudFormation template...");
-        parameterizeTemplate(template, assets);
-
-        // Add slack app manifest to the Outputs
-        console.log("Adding slack manifest to CloudFormation template...");
-        addSlackAppManifestOutputToTemplate(template);
-
-        // Modify template description to differentiate from cdk deployments
-        template.Description += ' (from S3 template)'
-
-        // Copy converted template to new S3 location
-        const convertedTemplateKey = `${destinationPrefix}/${templateName}`;
-        console.log(`Uploading converted template to s3://${destinationBucket}/${convertedTemplateKey}`);
-        await s3Client.send(new PutObjectCommand({
-            Bucket: destinationBucket,
-            Key: convertedTemplateKey,
-            Body: JSON.stringify(template, null, 2)
-        }));
-
-    } catch (error) {
-        console.error('An error occurred:', error);
-        process.exit(1);
+    // Zip and upload assets from cdk.out to new S3 location
+    for (let asset of assets) {
+      console.log(`Zipping and uploading asset: ${asset.key}`);
+      const zippedFilePath = await zipAsset(asset);
+      await uploadAsset(zippedFilePath, destinationBucket, destinationPrefix, asset.key);
+      fs.unlinkSync(zippedFilePath); // Clean up local zipped file
     }
+
+    // Update template with new asset paths
+    console.log('Updating CloudFormation template with new asset paths...');
+    updateTemplateLambdaAssetPaths(template, assets, destinationBucket, destinationPrefix);
+
+    // Remove remaining CDK vestiges
+    delete template.Parameters.BootstrapVersion;
+    delete template.Rules.CheckBootstrapVersion;
+
+    // Parameterize the environment variables
+    console.log('Adding parameters to CloudFormation template...');
+    parameterizeTemplate(template, assets);
+
+    // Add slack app manifest to the Outputs
+    console.log('Adding slack manifest to CloudFormation template...');
+    addSlackAppManifestOutputToTemplate(template);
+
+    // Modify template description to differentiate from cdk deployments
+    template.Description += ' (from S3 template)';
+
+    // Copy converted template to new S3 location
+    const convertedTemplateKey = `${destinationPrefix}/${templateName}`;
+    console.log(
+      `Uploading converted template to s3://${destinationBucket}/${convertedTemplateKey}`
+    );
+    await s3Client.send(
+      new PutObjectCommand({
+        Bucket: destinationBucket,
+        Key: convertedTemplateKey,
+        Body: JSON.stringify(template, null, 2)
+      })
+    );
+  } catch (error) {
+    console.error('An error occurred:', error);
+    process.exit(1);
+  }
 }
 
 function identifyLambdaAssets(template) {
-    let assets = [];
-    for (let [key, value] of Object.entries(template.Resources)) {
-        if (value.Type === "AWS::Lambda::Function" && value.Properties.Code?.S3Key) {
-            console.log(`Found asset in resource ${key}`);
-            assets.push({
-                key: value.Properties.Code.S3Key,
-                resourceName: key
-            });
-        }
+  let assets = [];
+  for (let [key, value] of Object.entries(template.Resources)) {
+    if (value.Type === 'AWS::Lambda::Function' && value.Properties.Code?.S3Key) {
+      console.log(`Found asset in resource ${key}`);
+      assets.push({
+        key: value.Properties.Code.S3Key,
+        resourceName: key
+      });
     }
-    return assets;
+  }
+  return assets;
 }
 
 async function zipAsset(asset) {
-    const assetHash = asset.key.split('.')[0]
-    const sourceDir = path.join('cdk.out', `asset.${assetHash}`);
-    const outPath = `${path.join('cdk.out', assetHash)}.zip`;
+  const assetHash = asset.key.split('.')[0];
+  const sourceDir = path.join('cdk.out', `asset.${assetHash}`);
+  const outPath = `${path.join('cdk.out', assetHash)}.zip`;
 
-    const zip = new JSZip();
-    const files = fs.readdirSync(sourceDir);
-    console.log(`Files: ${files}`)
-    files.forEach(file => {
-        const filePath = path.join(sourceDir, file);
-        const fileData = fs.readFileSync(filePath);
-        zip.file(file, fileData);
-    });
+  const zip = new JSZip();
+  const files = fs.readdirSync(sourceDir);
+  console.log(`Files: ${files}`);
+  files.forEach((file) => {
+    const filePath = path.join(sourceDir, file);
+    const fileData = fs.readFileSync(filePath);
+    zip.file(file, fileData);
+  });
 
-    await new Promise((resolve, reject) => {
-        zip
-            .generateNodeStream({ type: 'nodebuffer', streamFiles: true })
-            .pipe(fs.createWriteStream(outPath))
-            .on('finish', resolve) // Resolve the promise on finish
-            .on('error', reject);  // Reject the promise on error
-    });
+  await new Promise((resolve, reject) => {
+    zip
+      .generateNodeStream({ type: 'nodebuffer', streamFiles: true })
+      .pipe(fs.createWriteStream(outPath))
+      .on('finish', resolve) // Resolve the promise on finish
+      .on('error', reject); // Reject the promise on error
+  });
 
-    return outPath
+  return outPath;
 }
 
 async function uploadAsset(zippedFilePath, destinationBucket, destinationPrefix, originalKey) {
-    const fileStream = fs.createReadStream(zippedFilePath);
-    const destinationKey = `${destinationPrefix}/${path.basename(originalKey)}`;
+  const fileStream = fs.createReadStream(zippedFilePath);
+  const destinationKey = `${destinationPrefix}/${path.basename(originalKey)}`;
 
-    console.log(`Uploading zipped asset to s3://${destinationBucket}/${destinationKey}`);
+  console.log(`Uploading zipped asset to s3://${destinationBucket}/${destinationKey}`);
 
-    try {
-        const response = await s3Client.send(new PutObjectCommand({
-            Bucket: destinationBucket,
-            Key: destinationKey,
-            Body: fileStream
-        }));
-    } catch (error) {
-        console.error("An error occurred:", error);
-    }
+  try {
+    await s3Client.send(
+      new PutObjectCommand({
+        Bucket: destinationBucket,
+        Key: destinationKey,
+        Body: fileStream
+      })
+    );
+  } catch (error) {
+    console.error('An error occurred:', error);
+  }
 }
 
 function updateTemplateLambdaAssetPaths(template, assets, destinationBucket, destinationPrefix) {
-    for (let asset of assets) {
-        let lambdaResource = template.Resources[asset.resourceName];
-        lambdaResource.Properties.Code.S3Bucket = destinationBucket;
-        lambdaResource.Properties.Code.S3Key = `${destinationPrefix}/${path.basename(asset.key)}`;
-    }
+  for (let asset of assets) {
+    let lambdaResource = template.Resources[asset.resourceName];
+    lambdaResource.Properties.Code.S3Bucket = destinationBucket;
+    lambdaResource.Properties.Code.S3Key = `${destinationPrefix}/${path.basename(asset.key)}`;
+  }
 }
 
 function parameterizeTemplate(template, assets) {
-    template.Parameters = {
-        AmazonQUserId: {
-            Type: "String",
-            Default: "",
-            AllowedPattern: '(|^[\w.+-]+@([\w-]+\.)+[\w-]{2,6}$)',
-            Description: '(Optional) Amazon Q User ID email address (leave empty to use Slack users email as user Id)'
-        },
-        AmazonQAppId: {
-            Type: "String",
-            AllowedPattern: '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$',
-            Description: 'Existing Amazon Q Application ID (copy from Amazon Q console)'
-        },
-        AmazonQRegion: {
-            Type: "String",
-            Default: "us-east-1",
-            AllowedValues: ['us-east-1', 'us-west-2'],
-            Description: 'Amazon Q Region'
-        },
-        ContextDaysToLive: {
-            Type: "Number",
-            Default: 90,
-            MinValue: 1,
-            Description: 'Number of days to keep conversation context'
-        }
+  template.Parameters = {
+    AmazonQUserId: {
+      Type: 'String',
+      Default: '',
+      AllowedPattern: '(|^[\\w.+-]+@([\\w-]+\\.)+[\\w-]{2,6}$)',
+      Description:
+        '(Optional) Amazon Q User ID email address (leave empty to use Slack users email as user Id)'
+    },
+    AmazonQAppId: {
+      Type: 'String',
+      AllowedPattern: '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$',
+      Description: 'Existing Amazon Q Application ID (copy from Amazon Q console)'
+    },
+    AmazonQRegion: {
+      Type: 'String',
+      Default: 'us-east-1',
+      AllowedValues: ['us-east-1', 'us-west-2'],
+      Description: 'Amazon Q Region'
+    },
+    ContextDaysToLive: {
+      Type: 'Number',
+      Default: 90,
+      MinValue: 1,
+      Description: 'Number of days to keep conversation context'
     }
-    for (let asset of assets) {
-        let lambdaResource = template.Resources[asset.resourceName];
-        lambdaResource.Properties.Environment.Variables.AMAZON_Q_ENDPOINT = ''; // use default endpoint
-        lambdaResource.Properties.Environment.Variables.AMAZON_Q_USER_ID = { "Ref": "AmazonQUserId" };
-        lambdaResource.Properties.Environment.Variables.AMAZON_Q_APP_ID = { "Ref": "AmazonQAppId" };
-        lambdaResource.Properties.Environment.Variables.AMAZON_Q_REGION = { "Ref": "AmazonQRegion" };
-        lambdaResource.Properties.Environment.Variables.CONTEXT_DAYS_TO_LIVE = { "Ref": "ContextDaysToLive" };
-    }
+  };
+  for (let asset of assets) {
+    let lambdaResource = template.Resources[asset.resourceName];
+    lambdaResource.Properties.Environment.Variables.AMAZON_Q_ENDPOINT = ''; // use default endpoint
+    lambdaResource.Properties.Environment.Variables.AMAZON_Q_USER_ID = { Ref: 'AmazonQUserId' };
+    lambdaResource.Properties.Environment.Variables.AMAZON_Q_APP_ID = { Ref: 'AmazonQAppId' };
+    lambdaResource.Properties.Environment.Variables.AMAZON_Q_REGION = { Ref: 'AmazonQRegion' };
+    lambdaResource.Properties.Environment.Variables.CONTEXT_DAYS_TO_LIVE = {
+      Ref: 'ContextDaysToLive'
+    };
+  }
 }
 
 function replaceSubstringInObject(obj, searchValue, replaceValue) {
-    for (let key in obj) {
-        if (typeof obj[key] === 'string') {
-            obj[key] = obj[key].replace(searchValue, replaceValue);
-        } else if (typeof obj[key] === 'object') {
-            replaceSubstringInObject(obj[key], searchValue, replaceValue);
-        }
+  for (let key in obj) {
+    if (typeof obj[key] === 'string') {
+      obj[key] = obj[key].replace(searchValue, replaceValue);
+    } else if (typeof obj[key] === 'object') {
+      replaceSubstringInObject(obj[key], searchValue, replaceValue);
     }
+  }
 }
 
 function findOutputKey(obj, substring) {
-    let keys = Object.keys(obj).filter(key => key.includes(substring));
-    return keys[0] || null; // Return the first key or null if no match is found
+  let keys = Object.keys(obj).filter((key) => key.includes(substring));
+  return keys[0] || null; // Return the first key or null if no match is found
 }
 
 function addSlackAppManifestOutputToTemplate(template) {
-    // Read the manifest template
-    const manifestFile = 'slack-manifest-template.json';
-    console.log(`Reading slack app manifest template from ${manifestFile}...`);
-    const manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf8'));
-    // replace token string with variable
-    replaceSubstringInObject(manifest, '!!! \[SlackBotName\] !!!', '${SlackBotName}');
-    replaceSubstringInObject(manifest, '!!! \[SlackEventHandlerApiOutput\] !!!', '${SlackEventHandlerApiOutput}');
-    replaceSubstringInObject(manifest, '!!! \[SlackInteractionHandlerApiOutput\] !!!', '${SlackInteractionHandlerApiOutput}');
-    replaceSubstringInObject(manifest, '!!! \[SlackCommandApiOutput\] !!!', '${SlackCommandApiOutput}');
-    manifestString = JSON.stringify(manifest);
-    // get values for the token variables
-    SlackBotNameValue = { "Ref": "AWS::StackName" }
-    SlackEventHandlerApiOutputKey = findOutputKey(template.Outputs, 'SlackEventHandlerApiEndpoint');
-    SlackEventHandlerApiOutputValue = template.Outputs[SlackEventHandlerApiOutputKey].Value;
-    SlackInteractionHandlerApiOutputKey = findOutputKey(template.Outputs, 'SlackInteractionHandlerApiEndpoint');
-    SlackInteractionHandlerApiOutputValue = template.Outputs[SlackInteractionHandlerApiOutputKey].Value;
-    SlackCommandApiOutputKey = findOutputKey(template.Outputs, 'SlackCommandHandlerApiEndpoint');
-    SlackCommandApiOutputOutputValue = template.Outputs[SlackCommandApiOutputKey].Value;
-    // create manifest expression using Fn::Sub
-    manifestExpression = {
-        "Fn::Sub": [
-            manifestString,
-            {
-                SlackBotName: SlackBotNameValue,
-                SlackEventHandlerApiOutput: SlackEventHandlerApiOutputValue,
-                SlackInteractionHandlerApiOutput: SlackInteractionHandlerApiOutputValue,
-                SlackCommandApiOutput: SlackCommandApiOutputOutputValue
-            }
-        ]
-    }
-    // add manifest output to template
-    template.Outputs.SlackAppManifest = {
-        Value: manifestExpression,
-        Description: 'Slack app manifest JSON (copy/paste to create/update slack app)'
-    };
+  // Read the manifest template
+  const manifestFile = 'slack-manifest-template.json';
+  console.log(`Reading slack app manifest template from ${manifestFile}...`);
+  const manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf8'));
+  // replace token string with variable
+  replaceSubstringInObject(manifest, '!!! [SlackBotName] !!!', '${SlackBotName}');
+  replaceSubstringInObject(
+    manifest,
+    '!!! [SlackEventHandlerApiOutput] !!!',
+    '${SlackEventHandlerApiOutput}'
+  );
+  replaceSubstringInObject(
+    manifest,
+    '!!! [SlackInteractionHandlerApiOutput] !!!',
+    '${SlackInteractionHandlerApiOutput}'
+  );
+  replaceSubstringInObject(manifest, '!!! [SlackCommandApiOutput] !!!', '${SlackCommandApiOutput}');
+  const manifestString = JSON.stringify(manifest);
+  // get values for the token variables
+  const SlackBotNameValue = { Ref: 'AWS::StackName' };
+  const SlackEventHandlerApiOutputKey = findOutputKey(
+    template.Outputs,
+    'SlackEventHandlerApiEndpoint'
+  );
+  const SlackEventHandlerApiOutputValue = template.Outputs[SlackEventHandlerApiOutputKey].Value;
+  const SlackInteractionHandlerApiOutputKey = findOutputKey(
+    template.Outputs,
+    'SlackInteractionHandlerApiEndpoint'
+  );
+  const SlackInteractionHandlerApiOutputValue =
+    template.Outputs[SlackInteractionHandlerApiOutputKey].Value;
+  const SlackCommandApiOutputKey = findOutputKey(
+    template.Outputs,
+    'SlackCommandHandlerApiEndpoint'
+  );
+  const SlackCommandApiOutputOutputValue = template.Outputs[SlackCommandApiOutputKey].Value;
+  // create manifest expression using Fn::Sub
+  const manifestExpression = {
+    'Fn::Sub': [
+      manifestString,
+      {
+        SlackBotName: SlackBotNameValue,
+        SlackEventHandlerApiOutput: SlackEventHandlerApiOutputValue,
+        SlackInteractionHandlerApiOutput: SlackInteractionHandlerApiOutputValue,
+        SlackCommandApiOutput: SlackCommandApiOutputOutputValue
+      }
+    ]
+  };
+  // add manifest output to template
+  template.Outputs.SlackAppManifest = {
+    Value: manifestExpression,
+    Description: 'Slack app manifest JSON (copy/paste to create/update slack app)'
+  };
 }
 
 main();

--- a/bin/manifest.sh
+++ b/bin/manifest.sh
@@ -27,6 +27,7 @@ CDK_OUT_CONTENT=$(<"$CDK_OUT_FILE")
 SLACK_EVENT_HANDLER_API_OUTPUT=$(echo "$CDK_OUT_CONTENT" | jq -r '.[] | to_entries[] | select(.key | contains("SlackEventHandlerApiEndpoint")) | .value')
 SLACK_INTERACTION_HANDLER_API_OUTPUT=$(echo "$CDK_OUT_CONTENT" | jq -r '.[] | to_entries[] | select(.key | contains("SlackInteractionHandlerApiEndpoint")) | .value')
 SLACK_COMMAND_HANDLER_API_OUTPUT=$(echo "$CDK_OUT_CONTENT" | jq -r '.[] | to_entries[] | select(.key | contains("SlackCommandHandlerApiEndpoint")) | .value')
+SLACK_SECRET_URL_OUTPUT=$(echo "$CDK_OUT_CONTENT" | jq -r '.[] | to_entries[] | select(.key | contains("SlackSecretConsoleUrl")) | .value')
 
 # Use sed to replace the tokens with the extracted values in the template file and write to the new file
 if sed --version 2>/dev/null | grep -q GNU; then # GNU sed
@@ -45,6 +46,5 @@ fi
 echo "Slack app manifest created: $OUTPUT_FILE."
 
 # Output URL to Secrets Manager
-AWS_REGION=${AWS_REGION:-$(aws configure get region)}
-echo URL for your slack bot secrets: https://$AWS_REGION.console.aws.amazon.com/secretsmanager/secret\?name\=${STACKNAME}-Secret\&region\=$AWS_REGION
+echo URL for your slack bot secrets: $SLACK_SECRET_URL_OUTPUT
 

--- a/bin/my-amazon-q-slack-bot.ts
+++ b/bin/my-amazon-q-slack-bot.ts
@@ -5,9 +5,9 @@ import { MyAmazonQSlackBotStack } from '../lib/my-amazon-q-slack-bot-stack';
 import { readFileSync } from 'fs';
 
 export interface StackEnvironment {
-  StackName: string
-  AmazonQAppId: string
-  AmazonQUserId: string
+  StackName: string;
+  AmazonQAppId: string;
+  AmazonQUserId: string;
   AmazonQRegion: string;
   AmazonQEndpoint?: string;
   ContextDaysToLive: string;
@@ -15,15 +15,32 @@ export interface StackEnvironment {
 
 const app = new cdk.App();
 const inputEnvFile = app.node.tryGetContext('environment');
-if (inputEnvFile === undefined) { throw new Error("An input environment file is required"); }
+if (inputEnvFile === undefined) {
+  throw new Error('An input environment file is required');
+}
 
 const environment = JSON.parse(readFileSync(inputEnvFile).toString()) as StackEnvironment;
-if (environment.StackName === undefined) { throw new Error("StackName is required"); }
-if (environment.AmazonQAppId === undefined) { throw new Error("AmazonQAppId is required"); }
-if (environment.AmazonQRegion === undefined) { throw new Error("AmazonQRegion is required"); }
-if (environment.AmazonQUserId === undefined) { throw new Error("AmazonQUserId is required"); }
-if (environment.ContextDaysToLive === undefined) { throw new Error("ContextDaysToLive is required"); }
+if (environment.StackName === undefined) {
+  throw new Error('StackName is required');
+}
+if (environment.AmazonQAppId === undefined) {
+  throw new Error('AmazonQAppId is required');
+}
+if (environment.AmazonQRegion === undefined) {
+  throw new Error('AmazonQRegion is required');
+}
+if (environment.AmazonQUserId === undefined) {
+  throw new Error('AmazonQUserId is required');
+}
+if (environment.ContextDaysToLive === undefined) {
+  throw new Error('ContextDaysToLive is required');
+}
 
-new MyAmazonQSlackBotStack(app, 'AmazonQSlackGatewayStack', {
-  stackName: environment.StackName,
-}, environment);
+new MyAmazonQSlackBotStack(
+  app,
+  'AmazonQSlackGatewayStack',
+  {
+    stackName: environment.StackName
+  },
+  environment
+);

--- a/lib/my-amazon-q-slack-bot-stack.ts
+++ b/lib/my-amazon-q-slack-bot-stack.ts
@@ -44,9 +44,8 @@ export class MyAmazonQSlackBotStack extends cdk.Stack {
       secretStringValue: cdk.SecretValue.unsafePlainText(initialSecretContent)
     });
     // Output URL to the secret in the AWS Management Console
-    const secretConsoleUrl = `https://${this.region}.console.aws.amazon.com/secretsmanager/secret?name=${slackSecret.secretName}&region=${this.region}`;
     new CfnOutput(this, 'SlackSecretConsoleUrl', {
-      value: secretConsoleUrl,
+      value: `https://${this.region}.console.aws.amazon.com/secretsmanager/secret?name=${slackSecret.secretName}&region=${this.region}`,
       description: 'Click to edit the Slack secrets in the AWS Secrets Manager console'
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "my_amazon_q_slack_bot",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "my_amazon_q_slack_bot",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.465.0",
         "@aws-sdk/client-s3": "^3.465.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,16 @@
       "name": "my_amazon_q_slack_bot",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/client-cloudformation": "^3.465.0",
+        "@aws-sdk/client-s3": "^3.465.0",
+        "@aws-sdk/lib-dynamodb": "^3.465.0",
         "@slack/web-api": "^6.10.0",
         "@types/aws-lambda": "^8.10.119",
+        "archiver": "^6.0.1",
         "aws-cdk-lib": "^2.110.1",
         "aws-sdk": "^2.1452.0",
         "constructs": "^10.0.0",
+        "jszip": "^3.10.1",
         "pako": "^2.1.0",
         "source-map-support": "^0.5.21",
         "uuid": "^9.0.1",
@@ -34,6 +39,7 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
         "jest": "^29.0.0",
+        "jszip": "^3.10.1",
         "prettier": "^3.0.3",
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
@@ -76,6 +82,948 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
       "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
+      "integrity": "sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-3.0.0.tgz",
+      "integrity": "sha512-NJth5c997GLHs6nOYTzFKTbYdMNA6/1XlKVgnZoaZcQ7z7UJlOgj2JdbHE8tiYLS3fzXNCguct77SPGat2raSw==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-cloudformation": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.465.0.tgz",
+      "integrity": "sha512-w9Fy4F77IBLAD2kuoesOULGpIpjjgPWOoZ/xGhFKcQzlvam7nlz9Vs/1zS1uYjW8DCZO9mk7bTyq5uC0GrIaEA==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.465.0",
+        "@aws-sdk/core": "3.465.0",
+        "@aws-sdk/credential-provider-node": "3.465.0",
+        "@aws-sdk/middleware-host-header": "3.465.0",
+        "@aws-sdk/middleware-logger": "3.465.0",
+        "@aws-sdk/middleware-recursion-detection": "3.465.0",
+        "@aws-sdk/middleware-signing": "3.465.0",
+        "@aws-sdk/middleware-user-agent": "3.465.0",
+        "@aws-sdk/region-config-resolver": "3.465.0",
+        "@aws-sdk/types": "3.465.0",
+        "@aws-sdk/util-endpoints": "3.465.0",
+        "@aws-sdk/util-user-agent-browser": "3.465.0",
+        "@aws-sdk/util-user-agent-node": "3.465.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-utf8": "^2.0.2",
+        "@smithy/util-waiter": "^2.0.13",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.465.0.tgz",
+      "integrity": "sha512-ruYGPuz6IliiPm7dBZhibzJWN15corMTM10xIGG4YZH1igrvM5uvu1ab6OdNi3JfjNuG0eKHK8Q7vN9bSYcQeQ==",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.465.0",
+        "@aws-sdk/core": "3.465.0",
+        "@aws-sdk/credential-provider-node": "3.465.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.465.0",
+        "@aws-sdk/middleware-host-header": "3.465.0",
+        "@aws-sdk/middleware-logger": "3.465.0",
+        "@aws-sdk/middleware-recursion-detection": "3.465.0",
+        "@aws-sdk/middleware-signing": "3.465.0",
+        "@aws-sdk/middleware-user-agent": "3.465.0",
+        "@aws-sdk/region-config-resolver": "3.465.0",
+        "@aws-sdk/types": "3.465.0",
+        "@aws-sdk/util-endpoints": "3.465.0",
+        "@aws-sdk/util-user-agent-browser": "3.465.0",
+        "@aws-sdk/util-user-agent-node": "3.465.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-utf8": "^2.0.2",
+        "@smithy/util-waiter": "^2.0.13",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.465.0.tgz",
+      "integrity": "sha512-S2W8aUs/SR7wabyKRldl5FKtAq2gsXo3BpbKjBvuCILwNl84ooQrsOmKtcVsINRdi+q/mZvwGenqqp/98+yjdg==",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "3.0.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.465.0",
+        "@aws-sdk/core": "3.465.0",
+        "@aws-sdk/credential-provider-node": "3.465.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.465.0",
+        "@aws-sdk/middleware-expect-continue": "3.465.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.465.0",
+        "@aws-sdk/middleware-host-header": "3.465.0",
+        "@aws-sdk/middleware-location-constraint": "3.465.0",
+        "@aws-sdk/middleware-logger": "3.465.0",
+        "@aws-sdk/middleware-recursion-detection": "3.465.0",
+        "@aws-sdk/middleware-sdk-s3": "3.465.0",
+        "@aws-sdk/middleware-signing": "3.465.0",
+        "@aws-sdk/middleware-ssec": "3.465.0",
+        "@aws-sdk/middleware-user-agent": "3.465.0",
+        "@aws-sdk/region-config-resolver": "3.465.0",
+        "@aws-sdk/signature-v4-multi-region": "3.465.0",
+        "@aws-sdk/types": "3.465.0",
+        "@aws-sdk/util-endpoints": "3.465.0",
+        "@aws-sdk/util-user-agent-browser": "3.465.0",
+        "@aws-sdk/util-user-agent-node": "3.465.0",
+        "@aws-sdk/xml-builder": "3.465.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/eventstream-serde-browser": "^2.0.13",
+        "@smithy/eventstream-serde-config-resolver": "^2.0.13",
+        "@smithy/eventstream-serde-node": "^2.0.13",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-blob-browser": "^2.0.14",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/hash-stream-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/md5-js": "^2.0.15",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-stream": "^2.0.20",
+        "@smithy/util-utf8": "^2.0.2",
+        "@smithy/util-waiter": "^2.0.13",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.465.0.tgz",
+      "integrity": "sha512-JXDBa3Sl+LS0KEOs0PZoIjpNKEEGfeyFwdnRxi8Y1hMXNEKyJug1cI2Psqu2olpn4KeXwoP1BuITppZYdolOew==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.465.0",
+        "@aws-sdk/middleware-host-header": "3.465.0",
+        "@aws-sdk/middleware-logger": "3.465.0",
+        "@aws-sdk/middleware-recursion-detection": "3.465.0",
+        "@aws-sdk/middleware-user-agent": "3.465.0",
+        "@aws-sdk/region-config-resolver": "3.465.0",
+        "@aws-sdk/types": "3.465.0",
+        "@aws-sdk/util-endpoints": "3.465.0",
+        "@aws-sdk/util-user-agent-browser": "3.465.0",
+        "@aws-sdk/util-user-agent-node": "3.465.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.465.0.tgz",
+      "integrity": "sha512-rHi9ba6ssNbVjlWSdhi4C5newEhGhzkY9UE4KB+/Tj21zXfEP8r6uIltnQXPtun2SdA95Krh/yS1qQ4MRuzqyA==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.465.0",
+        "@aws-sdk/credential-provider-node": "3.465.0",
+        "@aws-sdk/middleware-host-header": "3.465.0",
+        "@aws-sdk/middleware-logger": "3.465.0",
+        "@aws-sdk/middleware-recursion-detection": "3.465.0",
+        "@aws-sdk/middleware-sdk-sts": "3.465.0",
+        "@aws-sdk/middleware-signing": "3.465.0",
+        "@aws-sdk/middleware-user-agent": "3.465.0",
+        "@aws-sdk/region-config-resolver": "3.465.0",
+        "@aws-sdk/types": "3.465.0",
+        "@aws-sdk/util-endpoints": "3.465.0",
+        "@aws-sdk/util-user-agent-browser": "3.465.0",
+        "@aws-sdk/util-user-agent-node": "3.465.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-utf8": "^2.0.2",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.465.0.tgz",
+      "integrity": "sha512-fHSIw/Rgex3KbrEKn6ZrUc2VcsOTpdBMeyYtfmsTOLSyDDOG9k3jelOvVbCbrK5N6uEUSM8hrnySEKg94UB0cg==",
+      "dependencies": {
+        "@smithy/smithy-client": "^2.1.15",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.465.0.tgz",
+      "integrity": "sha512-fku37AgkB9KhCuWHE6mfvbWYU0X84Df6MQ60nYH7s/PiNEhkX2cVI6X6kOKjP1MNIwRcYt+oQDvplVKdHume+A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.465.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.465.0.tgz",
+      "integrity": "sha512-B1MFufvdToAEMtfszilVnKer2S7P/OfMhkCizq2zuu8aU/CquRyHvKEQgWdvqunUDrFnVTc0kUZgsbBY0uPjLg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.465.0",
+        "@aws-sdk/credential-provider-process": "3.465.0",
+        "@aws-sdk/credential-provider-sso": "3.465.0",
+        "@aws-sdk/credential-provider-web-identity": "3.465.0",
+        "@aws-sdk/types": "3.465.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.465.0.tgz",
+      "integrity": "sha512-R3VA9yJ0BvezvrDxcgPTv9VHbVPbzchLTrX5jLFSVuW/lPPYLUi/Cjtyg9C9Y7qRfoQS4fNMvSRhwO5/TF68gA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.465.0",
+        "@aws-sdk/credential-provider-ini": "3.465.0",
+        "@aws-sdk/credential-provider-process": "3.465.0",
+        "@aws-sdk/credential-provider-sso": "3.465.0",
+        "@aws-sdk/credential-provider-web-identity": "3.465.0",
+        "@aws-sdk/types": "3.465.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.465.0.tgz",
+      "integrity": "sha512-YE6ZrRYwvb8969hWQnr4uvOJ8RU0JrNsk3vWTe/czly37ioZUEhi8jmpQp4f2mX/6U6buoFGWu5Se3VCdw2SFQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.465.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.465.0.tgz",
+      "integrity": "sha512-tLIP/4JQIJpn8yIg6RZRQ2nmvj5i4wLZvYvY4RtaFv2JrQUkmmTfyOZJuOBrIFRwJjx0fHmFu8DJjcOhMzllIQ==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.465.0",
+        "@aws-sdk/token-providers": "3.465.0",
+        "@aws-sdk/types": "3.465.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.465.0.tgz",
+      "integrity": "sha512-B4Y75fMTZIniEU0yyqat+9NsQbYlXdqP5Y3bShkaG3pGLOHzF/xMlWuG+D3kkQ806PLYi+BgfVls4BcO+NyVcA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.465.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.465.0.tgz",
+      "integrity": "sha512-0cuotk23hVSrqxHkJ3TTWC9MVMRgwlUvCatyegJEauJnk8kpLSGXE5KVdExlUBwShGNlj7ac29okZ9m17iTi5Q==",
+      "peer": true,
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-dynamodb": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.465.0.tgz",
+      "integrity": "sha512-l/jxVkdoetTsBaWxffC8X9Gp0k5m7I6yM0dMow+p0fCzOip5JVkSBI08dgQZGD0ECzxBEwW8vxdu84BLn2sS0A==",
+      "dependencies": {
+        "@aws-sdk/util-dynamodb": "3.465.0",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.465.0.tgz",
+      "integrity": "sha512-cyIR9Nwyie6giLypuLSUmZF3O5GqVRwia3Nq1B/6/Ho0LccH0/HT2x/nM8fFcnskWSNGTVZVvZzSrVYXynTtjA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.465.0",
+        "@aws-sdk/util-arn-parser": "3.465.0",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/types": "^2.5.0",
+        "@smithy/util-config-provider": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.465.0.tgz",
+      "integrity": "sha512-11Eq9BIKBHTi+y8ClgFMDbv4NyFEqUHm9CuAaPHy1PBYItp6ajqjjZi7yIjsM6KHba1br9SqtsuGfaFnWxWRSg==",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "3.465.0",
+        "@aws-sdk/types": "3.465.0",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.465.0.tgz",
+      "integrity": "sha512-kthlPQDASsdtdVqKVKkJn9bHptcEpsQ6ptWeGBCYigicULvWI1fjSTeXrYczxNMVg+1Sv8xkb/bh+kUEu7mvZg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.465.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.465.0.tgz",
+      "integrity": "sha512-joWEWN0v1CpI4q9JlZki0AchVwLL8Les0+V+3JHVDcDgL4RQ04YUk9lMYbtldDwdyBNquKwW2+sGtIo/6ng0Tg==",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-crypto/crc32c": "3.0.0",
+        "@aws-sdk/types": "3.465.0",
+        "@smithy/is-array-buffer": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/types": "^2.5.0",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.465.0.tgz",
+      "integrity": "sha512-nnGva8eplwEJqdVzcb+xF2Fwua0PpiwxMEvpnIy73gNbetbJdgFIprryMLYes00xzJEqnew+LWdpcd3YyS34ZA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.465.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.465.0.tgz",
+      "integrity": "sha512-2+mwaI/ltE2ibr5poC+E9kJRfVIv7aHpAJkLu7uvESch9cpuFuGJu6fq0/gA82eKZ/gwpBj+AaXBsDFfsDWFsw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.465.0",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.465.0.tgz",
+      "integrity": "sha512-aGMx1aSlzDDgjZ7fSxLhGD5rkyCfHwq04TSB5fQAgDBqUjj4IQXZwmNglX0sLRmArXZtDglUVESOfKvTANJTPg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.465.0",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.465.0.tgz",
+      "integrity": "sha512-ol3dlsTnryBhV5qkUvK5Yg3dRaV1NXIxYJaIkShrl8XAv4wRNcDJDmO5NYq5eVZ3zgV1nv6xIpZ//dDnnf6Z+g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.465.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.465.0.tgz",
+      "integrity": "sha512-P4cpNv0EcMSSLojjqKKQjKSGZc13QJQAscUs+fcvpBg2BNR9ByxrQgXXMqQiIqr8fgAhADqN2Tp8hJk0CzfnAg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.465.0",
+        "@aws-sdk/util-arn-parser": "3.465.0",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/util-config-provider": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.465.0.tgz",
+      "integrity": "sha512-PmTM5ycUe1RLAPrQXLCR8JzKamJuKDB0aIW4rx4/skurzWsEGRI47WHggf9N7sPie41IBGUhRbXcf7sfPjvI3Q==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.465.0",
+        "@aws-sdk/types": "3.465.0",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.465.0.tgz",
+      "integrity": "sha512-d90KONWXSC3jA0kqJ6u8ygS4LoMg1TmSM7bPhHyibJVAEhnrlB4Aq1CWljNbbtphGpdKy5/XRM9O0/XCXWKQ4w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.465.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/types": "^2.5.0",
+        "@smithy/util-middleware": "^2.0.6",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.465.0.tgz",
+      "integrity": "sha512-PHc1guBGp7fwoPlJkAEaHVkiYPfs93jffwsBvIevCsHcfYPv6L26/5Nk7KR+6IyuGQHpUbSC080SP1jYjOy01A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.465.0",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.465.0.tgz",
+      "integrity": "sha512-1MvIWMj2nktLOJN8Kh4jiTK28oL85fTeoXHZ+V8xYMzont6C6Y8gQPtg7ka+RotHwqWMrovfnANisnX8EzEP/Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.465.0",
+        "@aws-sdk/util-endpoints": "3.465.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.465.0.tgz",
+      "integrity": "sha512-h0Phd2Ae873dsPSWuxqxz2yRC5NMeeWxQiJPh4j42HF8g7dZK7tMQPkYznAoA/BzSBsEX87sbr3MmigquSyUTA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/types": "^2.5.0",
+        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.6",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.465.0.tgz",
+      "integrity": "sha512-p620S4YCr2CPNIdSnRvBqScAqWztjef9EwtD1MAkxTTrjNAyxSCf4apeQ2pdaWNNkJT1vSc/YKBAJ7l2SWn7rw==",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.465.0",
+        "@aws-sdk/types": "3.465.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.465.0.tgz",
+      "integrity": "sha512-NaZbsyLs3whzRHGV27hrRwEdXB/tEK6tqn/aCNBy862LhVzocY1A+eYLKrnrvpraOOd2vyAuOtvvB3RMIdiL6g==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.465.0",
+        "@aws-sdk/middleware-logger": "3.465.0",
+        "@aws-sdk/middleware-recursion-detection": "3.465.0",
+        "@aws-sdk/middleware-user-agent": "3.465.0",
+        "@aws-sdk/region-config-resolver": "3.465.0",
+        "@aws-sdk/types": "3.465.0",
+        "@aws-sdk/util-endpoints": "3.465.0",
+        "@aws-sdk/util-user-agent-browser": "3.465.0",
+        "@aws-sdk/util-user-agent-node": "3.465.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.465.0.tgz",
+      "integrity": "sha512-Clqu2eD50OOzwSftGpzJrIOGev/7VJhJpc02SeS4cqFgI9EVd+rnFKS/Ux0kcwjLQBMiPcCLtql3KAHApFHAIA==",
+      "dependencies": {
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.465.0.tgz",
+      "integrity": "sha512-zOJ82vzDJFqBX9yZBlNeHHrul/kpx/DCoxzW5UBbZeb26kfV53QhMSoEmY8/lEbBqlqargJ/sgRC845GFhHNQw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.465.0.tgz",
+      "integrity": "sha512-Zi3ThmR7zfNH32CV5nsVf4Ce6gkX1N/wnxMdTQv2qnu1zoA/6o7RPzrGs92EafDHugvRXJFoWM5oHjYBreK61Q==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.465.0.tgz",
+      "integrity": "sha512-lDpBN1faVw8Udg5hIo+LJaNfllbBF86PCisv628vfcggO8/EArL/v2Eos0KeqVT8yaINXCRSagwfo5TNTuW0KQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.465.0",
+        "@smithy/util-endpoints": "^1.0.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.465.0.tgz",
+      "integrity": "sha512-f+QNcWGswredzC1ExNAB/QzODlxwaTdXkNT5cvke2RLX8SFU5pYk6h4uCtWC0vWPELzOfMfloBrJefBzlarhsw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.465.0.tgz",
+      "integrity": "sha512-RM+LjkIsmUCBJ4yQeBnkJWJTjPOPqcNaKv8bpZxatIHdvzGhXLnWLNi3qHlBsJB2mKtKRet6nAUmKmzZR1sDzA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.465.0",
+        "@smithy/types": "^2.5.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.465.0.tgz",
+      "integrity": "sha512-XsHbq7gLCiGdy6FQ7/5nGslK0ij3Iuh051djuIICvNurlds5cqKLiBe63gX3IUUwxJcrKh4xBGviQJ52KdVSeg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.465.0",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/types": "^2.5.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.465.0.tgz",
+      "integrity": "sha512-9TKW5ZgsReygePTnAUdvaqxr/k1HXsEz2yDnk/jTLaUeRPsd5la8fFjb6OfgYYlbEVNlxTcKzaqOdrqxpUkmyQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.23.4",
@@ -1427,6 +2375,630 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.14.tgz",
+      "integrity": "sha512-zXtteuYLWbSXnzI3O6xq3FYvigYZFW8mdytGibfarLL2lxHto9L3ILtGVnVGmFZa7SDh62l39EnU5hesLN87Fw==",
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-2.0.0.tgz",
+      "integrity": "sha512-k+J4GHJsMSAIQPChGBrjEmGS+WbPonCXesoqP9fynIqjn7rdOThdH8FAeCmokP9mxTYKQAKoHCLPzNlm6gh7Wg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-2.0.1.tgz",
+      "integrity": "sha512-N2oCZRglhWKm7iMBu7S6wDzXirjAofi7tAd26cxmgibRYOBS4D3hGfmkwCpHdASZzwZDD8rluh0Rcqw1JeZDRw==",
+      "dependencies": {
+        "@smithy/util-base64": "^2.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.19.tgz",
+      "integrity": "sha512-JsghnQ5zjWmjEVY8TFOulLdEOCj09SjRLugrHlkPZTIBBm7PQitCFVLThbsKPZQOP7N3ME1DU1nKUc1UaVnBog==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.1.6",
+        "@smithy/types": "^2.6.0",
+        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.7",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.1.2.tgz",
+      "integrity": "sha512-Y62jBWdoLPSYjr9fFvJf+KwTa1EunjVr6NryTEWCnwIY93OJxwV4t0qxjwdPl/XMsUkq79ppNJSEQN6Ohnhxjw==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.1.6",
+        "@smithy/property-provider": "^2.0.15",
+        "@smithy/types": "^2.6.0",
+        "@smithy/url-parser": "^2.0.14",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.14.tgz",
+      "integrity": "sha512-g/OU/MeWGfHDygoXgMWfG/Xb0QqDnAGcM9t2FRrVAhleXYRddGOEnfanR5cmHgB9ue52MJsyorqFjckzXsylaA==",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.6.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.0.14.tgz",
+      "integrity": "sha512-41wmYE9smDGJi1ZXp+LogH6BR7MkSsQD91wneIFISF/mupKULvoOJUkv/Nf0NMRxWlM3Bf1Vvi9FlR2oV4KU8Q==",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^2.0.14",
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.0.14.tgz",
+      "integrity": "sha512-43IyRIzQ82s+5X+t/3Ood00CcWtAXQdmUIUKMed2Qg9REPk8SVIHhpm3rwewLwg+3G2Nh8NOxXlEQu6DsPUcMw==",
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.0.14.tgz",
+      "integrity": "sha512-jVh9E2qAr6DxH5tWfCAl9HV6tI0pEQ3JVmu85JknDvYTC66djcjDdhctPV2EHuKWf2kjRiFJcMIn0eercW4THA==",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^2.0.14",
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.0.14.tgz",
+      "integrity": "sha512-Ie35+AISNn1NmEjn5b2SchIE49pvKp4Q74bE9ME5RULWI1MgXyGkQUajWd5E6OBSr/sqGcs+rD3IjPErXnCm9g==",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^2.0.14",
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.7.tgz",
+      "integrity": "sha512-iSDBjxuH9TgrtMYAr7j5evjvkvgwLY3y+9D547uep+JNkZ1ZT+BaeU20j6I/bO/i26ilCWFImrlXTPsfQtZdIQ==",
+      "dependencies": {
+        "@smithy/protocol-http": "^3.0.10",
+        "@smithy/querystring-builder": "^2.0.14",
+        "@smithy/types": "^2.6.0",
+        "@smithy/util-base64": "^2.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-2.0.15.tgz",
+      "integrity": "sha512-HX/7GIyPUT/HDWVYe2HYQu0iRnSYpF4uZVNhAhZsObPRawk5Mv0PbyluBgIFI2DDCCKgL/tloCYYwycff1GtQg==",
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^2.0.0",
+        "@smithy/chunked-blob-reader-native": "^2.0.1",
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.16.tgz",
+      "integrity": "sha512-Wbi9A0PacMYUOwjAulQP90Wl3mQ6NDwnyrZQzFjDz+UzjXOSyQMgBrTkUBz+pVoYVlX3DUu24gWMZBcit+wOGg==",
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-2.0.16.tgz",
+      "integrity": "sha512-4x24GFdeWos1Z49MC5sYdM1j+z32zcUr6oWM9Ggm3WudFAcRIcbG9uDQ1XgJ0Kl+ZTjpqLKniG0iuWvQb2Ud1A==",
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.14.tgz",
+      "integrity": "sha512-d8ohpwZo9RzTpGlAfsWtfm1SHBSU7+N4iuZ6MzR10xDTujJJWtmXYHK1uzcr7rggbpUTaWyHpPFgnf91q0EFqQ==",
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
+      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.0.16.tgz",
+      "integrity": "sha512-YhWt9aKl+EMSNXyUTUo7I01WHf3HcCkPu/Hl2QmTNwrHT49eWaY7hptAMaERZuHFH0V5xHgPKgKZo2I93DFtgQ==",
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.16.tgz",
+      "integrity": "sha512-9ddDia3pp1d3XzLXKcm7QebGxLq9iwKf+J1LapvlSOhpF8EM9SjMeSrMOOFgG+2TfW5K3+qz4IAJYYm7INYCng==",
+      "dependencies": {
+        "@smithy/protocol-http": "^3.0.10",
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.2.1.tgz",
+      "integrity": "sha512-dVDS7HNJl/wb0lpByXor6whqDbb1YlLoaoWYoelyYzLHioXOE7y/0iDwJWtDcN36/tVCw9EPBFZ3aans84jLpg==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^2.0.14",
+        "@smithy/node-config-provider": "^2.1.6",
+        "@smithy/shared-ini-file-loader": "^2.2.5",
+        "@smithy/types": "^2.6.0",
+        "@smithy/url-parser": "^2.0.14",
+        "@smithy/util-middleware": "^2.0.7",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.21.tgz",
+      "integrity": "sha512-EZS1EXv1k6IJX6hyu/0yNQuPcPaXwG8SWljQHYueyRbOxmqYgoWMWPtfZj0xRRQ4YtLawQSpBgAeiJltq8/MPw==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.1.6",
+        "@smithy/protocol-http": "^3.0.10",
+        "@smithy/service-error-classification": "^2.0.7",
+        "@smithy/types": "^2.6.0",
+        "@smithy/util-middleware": "^2.0.7",
+        "@smithy/util-retry": "^2.0.7",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.14.tgz",
+      "integrity": "sha512-hFi3FqoYWDntCYA2IGY6gJ6FKjq2gye+1tfxF2HnIJB5uW8y2DhpRNBSUMoqP+qvYzRqZ6ntv4kgbG+o3pX57g==",
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.8.tgz",
+      "integrity": "sha512-7/N59j0zWqVEKExJcA14MrLDZ/IeN+d6nbkN8ucs+eURyaDUXWYlZrQmMOd/TyptcQv0+RDlgag/zSTTV62y/Q==",
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.6.tgz",
+      "integrity": "sha512-HLqTs6O78m3M3z1cPLFxddxhEPv5MkVatfPuxoVO3A+cHZanNd/H5I6btcdHy6N2CB1MJ/lihJC92h30SESsBA==",
+      "dependencies": {
+        "@smithy/property-provider": "^2.0.15",
+        "@smithy/shared-ini-file-loader": "^2.2.5",
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.10.tgz",
+      "integrity": "sha512-lkALAwtN6odygIM4nB8aHDahINM6WXXjNrZmWQAh0RSossySRT2qa31cFv0ZBuAYVWeprskRk13AFvvLmf1WLw==",
+      "dependencies": {
+        "@smithy/abort-controller": "^2.0.14",
+        "@smithy/protocol-http": "^3.0.10",
+        "@smithy/querystring-builder": "^2.0.14",
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.15.tgz",
+      "integrity": "sha512-YbRFBn8oiiC3o1Kn3a4KjGa6k47rCM9++5W9cWqYn9WnkyH+hBWgfJAckuxpyA2Hq6Ys4eFrWzXq6fqHEw7iew==",
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.10.tgz",
+      "integrity": "sha512-6+tjNk7rXW7YTeGo9qwxXj/2BFpJTe37kTj3EnZCoX/nH+NP/WLA7O83fz8XhkGqsaAhLUPo/bB12vvd47nsmg==",
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.14.tgz",
+      "integrity": "sha512-lQ4pm9vTv9nIhl5jt6uVMPludr6syE2FyJmHsIJJuOD7QPIJnrf9HhUGf1iHh9KJ4CUv21tpOU3X6s0rB6uJ0g==",
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "@smithy/util-uri-escape": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.14.tgz",
+      "integrity": "sha512-+cbtXWI9tNtQjlgQg3CA+pvL3zKTAxPnG3Pj6MP89CR3vi3QMmD0SOWoq84tqZDnJCxlsusbgIXk1ngMReXo+A==",
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.7.tgz",
+      "integrity": "sha512-LLxgW12qGz8doYto15kZ4x1rHjtXl0BnCG6T6Wb8z2DI4PT9cJfOSvzbuLzy7+5I24PAepKgFeWHRd9GYy3Z9w==",
+      "dependencies": {
+        "@smithy/types": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.5.tgz",
+      "integrity": "sha512-LHA68Iu7SmNwfAVe8egmjDCy648/7iJR/fK1UnVw+iAOUJoEYhX2DLgVd5pWllqdDiRbQQzgaHLcRokM+UFR1w==",
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.16.tgz",
+      "integrity": "sha512-ilLY85xS2kZZzTb83diQKYLIYALvart0KnBaKnIRnMBHAGEio5aHSlANQoxVn0VsonwmQ3CnWhnCT0sERD8uTg==",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^2.0.14",
+        "@smithy/is-array-buffer": "^2.0.0",
+        "@smithy/types": "^2.6.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.7",
+        "@smithy/util-uri-escape": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.16.tgz",
+      "integrity": "sha512-Lw67+yQSpLl4YkDLUzI2KgS8TXclXmbzSeOJUmRFS4ueT56B4pw3RZRF/SRzvgyxM/HxgkUan8oSHXCujPDafQ==",
+      "dependencies": {
+        "@smithy/middleware-stack": "^2.0.8",
+        "@smithy/types": "^2.6.0",
+        "@smithy/util-stream": "^2.0.21",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.6.0.tgz",
+      "integrity": "sha512-PgqxJq2IcdMF9iAasxcqZqqoOXBHufEfmbEUdN1pmJrJltT42b0Sc8UiYSWWzKkciIp9/mZDpzYi4qYG1qqg6g==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.14.tgz",
+      "integrity": "sha512-kbu17Y1AFXi5lNlySdDj7ZzmvupyWKCX/0jNZ8ffquRyGdbDZb+eBh0QnWqsSmnZa/ctyWaTf7n4l/pXLExrnw==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^2.0.14",
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.1.tgz",
+      "integrity": "sha512-DlI6XFYDMsIVN+GH9JtcRp3j02JEVuWIn/QOZisVzpIAprdsxGveFed0bjbMRCqmIFe8uetn5rxzNrBtIGrPIQ==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
+      "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
+      "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
+      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
+      "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.20.tgz",
+      "integrity": "sha512-QJtnbTIl0/BbEASkx1MUFf6EaoWqWW1/IM90N++8NNscePvPf77GheYfpoPis6CBQawUWq8QepTP2QUSAdrVkw==",
+      "dependencies": {
+        "@smithy/property-provider": "^2.0.15",
+        "@smithy/smithy-client": "^2.1.16",
+        "@smithy/types": "^2.6.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.26.tgz",
+      "integrity": "sha512-lGFPOFCHv1ql019oegYqa54BZH7HREw6EBqjDLbAr0wquMX0BDi2sg8TJ6Eq+JGLijkZbJB73m4+aK8OFAapMg==",
+      "dependencies": {
+        "@smithy/config-resolver": "^2.0.19",
+        "@smithy/credential-provider-imds": "^2.1.2",
+        "@smithy/node-config-provider": "^2.1.6",
+        "@smithy/property-provider": "^2.0.15",
+        "@smithy/smithy-client": "^2.1.16",
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.5.tgz",
+      "integrity": "sha512-K7qNuCOD5K/90MjHvHm9kJldrfm40UxWYQxNEShMFxV/lCCCRIg8R4uu1PFAxRvPxNpIdcrh1uK6I1ISjDXZJw==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.1.6",
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
+      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.7.tgz",
+      "integrity": "sha512-tRINOTlf1G9B0ECarFQAtTgMhpnrMPSa+5j4ZEwEawCLfTFTavk6757sxhE4RY5RMlD/I3x+DCS8ZUiR8ho9Pw==",
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.7.tgz",
+      "integrity": "sha512-fIe5yARaF0+xVT1XKcrdnHKTJ1Vc4+3e3tLDjCuIcE9b6fkBzzGFY7AFiX4M+vj6yM98DrwkuZeHf7/hmtVp0Q==",
+      "dependencies": {
+        "@smithy/service-error-classification": "^2.0.7",
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.21.tgz",
+      "integrity": "sha512-0BUE16d7n1x7pi1YluXJdB33jOTyBChT0j/BlOkFa9uxfg6YqXieHxjHNuCdJRARa7AZEj32LLLEPJ1fSa4inA==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^2.2.7",
+        "@smithy/node-http-handler": "^2.1.10",
+        "@smithy/types": "^2.6.0",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
+      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.2.tgz",
+      "integrity": "sha512-qOiVORSPm6Ce4/Yu6hbSgNHABLP2VMv8QOC3tTDNHHlWY19pPyc++fBTbZPtx6egPXi4HQxKDnMxVxpbtX2GoA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.14.tgz",
+      "integrity": "sha512-Q6gSz4GUNjNGhrfNg+2Mjy+7K4pEI3r82x1b/+3dSc03MQqobMiUrRVN/YK/4nHVagvBELCoXsiHAFQJNQ5BeA==",
+      "dependencies": {
+        "@smithy/abort-controller": "^2.0.14",
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -1919,6 +3491,76 @@
         "node": ">= 8"
       }
     },
+    "node_modules/archiver": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-6.0.1.tgz",
+      "integrity": "sha512-CXGy4poOLBKptiZH//VlWdFuUC1RESbdZjGjILwBuZ73P7WkAUN0htfSfBq/7k6FRFlpu7bg4JOkj1vU9G6jcQ==",
+      "dependencies": {
+        "archiver-utils": "^4.0.1",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^5.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-4.0.1.tgz",
+      "integrity": "sha512-Q4Q99idbvzmgCTEAAhi32BkOyq8iVI5EwdO0PmBDSGIzzjYNdcFn7Q7k3OzbLy4kLUPXfJtG6fO2RjftXbobBg==",
+      "dependencies": {
+        "glob": "^8.0.0",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -2367,6 +4009,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
+      "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw=="
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -2486,8 +4133,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -2516,6 +4162,11 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "node_modules/bplist-parser": {
       "version": "0.2.0",
@@ -2612,6 +4263,14 @@
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -2829,6 +4488,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/compress-commons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-5.0.1.tgz",
+      "integrity": "sha512-MPh//1cERdLtqwO3pOFLeXtpuai0Y2WCd5AhtKxznqM7WtaMYaOEMSgn45d9D10sIHSfIKE603HlOp8OPGrvag==",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^5.0.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2848,6 +4521,34 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-5.0.0.tgz",
+      "integrity": "sha512-B0EPa1UK+qnpBZpG+7FgPCu0J2ETLpXq09o9BkLkEAhdB6Z61Qo4pJ3JYu0c+Qi+/SAL7QThqnzS06pmSSyZaw==",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -3504,6 +5205,11 @@
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+    },
     "node_modules/fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -3543,6 +5249,27 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -3675,8 +5402,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -3834,8 +5560,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -3939,6 +5664,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -3987,7 +5718,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4916,6 +6646,54 @@
         "node": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4939,6 +6717,44 @@
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
     },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -4961,6 +6777,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -4981,6 +6806,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -5117,6 +6947,15 @@
         "node": "*"
       }
     },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "peer": true,
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -5144,7 +6983,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5161,11 +6999,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "peer": true
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -5548,6 +7391,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -5620,6 +7468,11 @@
         }
       ]
     },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
+    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -5637,6 +7490,33 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/require-directory": {
@@ -5854,6 +7734,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -5961,6 +7847,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.5.tgz",
+      "integrity": "sha512-9thPGMkKC2GctCzyCUjME3yR03x2xNo0GPKGkRw2UMYN+gqWa9uqpyNWhmsNCutU5zHmkUum0LsCRQTXUgUCAg==",
+      "dependencies": {
+        "fast-fifo": "^1.1.0",
+        "queue-tick": "^1.0.1"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -6038,6 +7933,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6076,6 +7976,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
+      "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
       }
     },
     "node_modules/test-exclude": {
@@ -6251,8 +8161,7 @@
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6523,8 +8432,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
@@ -6620,6 +8528,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-5.0.1.tgz",
+      "integrity": "sha512-UfZ0oa0C8LI58wJ+moL46BDIMgCQbnsb+2PoiJYtonhBsMh2bq1eRBVkvjfVsqbEHd9/EgKPUuL9saSSsec8OA==",
+      "dependencies": {
+        "archiver-utils": "^4.0.1",
+        "compress-commons": "^5.0.1",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "watch": "tsc -w",
     "test": "jest",
     "cdk": "cdk",
-    "lint": "eslint . --ext .ts",
+    "lint": "eslint . --ext .ts,.js",
     "lint:fix": "npm run lint -- --fix"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,14 +29,20 @@
     "prettier": "^3.0.3",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
-    "typescript": "~4.6.3"
+    "typescript": "~4.6.3",
+    "jszip": "^3.10.1"
   },
   "dependencies": {
+    "@aws-sdk/client-cloudformation": "^3.465.0",
+    "@aws-sdk/client-s3": "^3.465.0",
+    "@aws-sdk/lib-dynamodb": "^3.465.0",
     "@slack/web-api": "^6.10.0",
     "@types/aws-lambda": "^8.10.119",
+    "archiver": "^6.0.1",
     "aws-cdk-lib": "^2.110.1",
     "aws-sdk": "^2.1452.0",
     "constructs": "^10.0.0",
+    "jszip": "^3.10.1",
     "pako": "^2.1.0",
     "source-map-support": "^0.5.21",
     "uuid": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my_amazon_q_slack_bot",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "bin": {
     "my_enterprise_q_slack_bot": "bin/my_amazon_q_slack_bot.js"
   },

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+##############################################################################################
+# Create new Cfn artifacts bucket if not already existing
+# Build artifacts and template with CDK
+# Convert templates from CDK dependent to standalone
+# Upload artifacts to S3 bucket for deployment with CloudFormation
+##############################################################################################
+
+# Stop the publish process on failures
+set -e
+
+USAGE="$0 <cfn_bucket_basename> <cfn_prefix> <region> [public]"
+
+BUCKET_BASENAME=$1
+[ -z "$BUCKET_BASENAME" ] && echo "Cfn bucket name is a required parameter. Usage $USAGE" && exit 1
+
+PREFIX=$2
+[ -z "$PREFIX" ] && echo "Prefix is a required parameter. Usage $USAGE" && exit 1
+
+REGION=$3
+[ -z "$REGION" ] && echo "Region is a required parameter. Usage $USAGE" && exit 1
+export AWS_DEFAULT_REGION=$REGION
+
+ACL=$4
+if [ "$ACL" == "public" ]; then
+  echo "Published S3 artifacts will be acessible by public (read-only)"
+  PUBLIC=true
+else
+  echo "Published S3 artifacts will NOT be acessible by public."
+  PUBLIC=false
+fi
+
+# Remove trailing slash from prefix if needed, and append VERSION
+VERSION=$(jq -r '.version' package.json)
+[[ "${PREFIX}" == */ ]] && PREFIX="${PREFIX%?}"
+PREFIX_AND_VERSION=${PREFIX}/${VERSION}
+
+# Append region to bucket basename
+BUCKET=${BUCKET_BASENAME}-${REGION}
+
+echo "Running precheck..."
+./bin/precheck.sh
+
+# Create bucket if it doesn't already exist
+if [ -x $(aws s3api list-buckets --query 'Buckets[].Name' | grep "\"$BUCKET\"") ]; then
+  echo "Creating s3 bucket: $BUCKET"
+  aws s3 mb s3://${BUCKET} || exit 1
+  aws s3api put-bucket-versioning --bucket ${BUCKET} --versioning-configuration Status=Enabled || exit 1
+else
+  echo "Using existing bucket: $BUCKET"
+fi
+
+echo "Create temp environment file"
+envfile=/tmp/environment.json
+cat > /tmp/environment.json << _EOF
+{
+  "StackName": "AQSG",
+  "AmazonQAppId": "QAPPID",
+  "AmazonQUserId": "QUSERID",
+  "AmazonQRegion": "QREGION",
+  "AmazonQEndpoint": "QENDPOINT",
+  "ContextDaysToLive": "QCONTEXTTTL"
+}
+_EOF
+
+echo "Running npm install and build..."
+npm install && npm run build
+
+echo "Running cdk bootstrap..."
+cdk bootstrap -c environment=./environment.json
+
+echo "Running cdk synthesize to create artifacts and template"
+cdk synthesize --staging  -c environment=$envfile > /dev/null
+
+echo "Converting and uploading Cfn artifacts to S3"
+CDKTEMPLATE="AmazonQSlackGatewayStack.template.json"
+node ./bin/convert-cfn-template.js $CDKTEMPLATE $BUCKET $PREFIX_AND_VERSION $REGION
+
+MAIN_TEMPLATE="AmazonQSlackGateway.json"
+aws s3 cp s3://${BUCKET}/${PREFIX_AND_VERSION}/${CDKTEMPLATE} s3://${BUCKET}/${PREFIX}/${MAIN_TEMPLATE} || exit 1
+
+template="https://s3.${REGION}.amazonaws.com/${BUCKET}/${PREFIX}/${MAIN_TEMPLATE}"
+echo "Validating converted template: $template"
+aws cloudformation validate-template --template-url $template > /dev/null || exit 1
+
+if $PUBLIC; then
+  echo "Setting public read ACLs on published artifacts"
+  files=$(aws s3api list-objects --bucket ${BUCKET} --prefix ${PREFIX_AND_VERSION} --query "(Contents)[].[Key]" --output text)
+  for file in $files
+    do
+    aws s3api put-object-acl --acl public-read --bucket ${BUCKET} --key $file
+    done
+  aws s3api put-object-acl --acl public-read --bucket ${BUCKET} --key ${PREFIX}/${MAIN_TEMPLATE}
+fi
+
+echo "OUTPUTS"
+echo Template URL: $template
+echo CF Launch URL: https://${REGION}.console.aws.amazon.com/cloudformation/home?region=${REGION}#/stacks/create/review?templateURL=${template}\&stackName=AMAZON-Q-SLACK-GATEWAY
+echo Done
+exit 0
+

--- a/publish.sh
+++ b/publish.sh
@@ -75,6 +75,7 @@ cdk synthesize --staging  -c environment=$envfile > /dev/null
 
 echo "Converting and uploading Cfn artifacts to S3"
 CDKTEMPLATE="AmazonQSlackGatewayStack.template.json"
+echo node ./bin/convert-cfn-template.js $CDKTEMPLATE $BUCKET $PREFIX_AND_VERSION $REGION
 node ./bin/convert-cfn-template.js $CDKTEMPLATE $BUCKET $PREFIX_AND_VERSION $REGION
 
 MAIN_TEMPLATE="AmazonQSlackGateway.json"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Modify resource naming in CDK app, to avoid dependency on static stack name from environment.json
- New template conversion script (js) to 
  - remove dependencies on cdk bootstrap bucket
  - add parameters for environment settings
  - add outputs for manifest, and secret URL
  - publish template and assets to designated S3 bucket/prefix/version
- New publish.sh script to create S3 artifacts bucket (if needed), template validation, publish main template, set ACLs, output URLs 

To publish CFn templates, run:
```
./publish.sh <bucket-basename> <prefix> <region> [public]
```
The template will be published to bucket: <bucket-basename>-<region>/<prefix>. 
Assets will be published to: <bucket-basename>-<region>/<prefix>/<version>
Template URLs are output by the script.

TODO: Update README to explain how and why to use the publish.sh script, and include links to templates we will publish to public S3 buckets.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
