### PR TITLE
slack command flexibility

### DIFF
--- a/src/functions/slack-command-handler.ts
+++ b/src/functions/slack-command-handler.ts
@@ -79,7 +79,7 @@ export const handler = async (
   }
 
   let commandStatus;
-  if (body.command === '/new_conversation') {
+  if (body.command.startsWith('/new_conv')) { 
     const channelKey = getChannelKey('message', body.team_id, body.channel_id, 'n/a');
     logger.debug(`Slash command: ${body.command} - deleting channel metadata for '${channelKey}'`);
     await deleteChannelMetadata(channelKey, dependencies, slackEventsEnv);


### PR DESCRIPTION
*Issue #, if available:*
N/A 
*Description of changes:*
This provides greater flexibility in case of many different bots within a workspace. The "/new_conversation" command is static which leads to conflict w/ in Slack. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
