### PR TITLE
fix: enable pitr for dynamo tables

### DIFF
--- a/lib/my-amazon-q-slack-bot-stack.ts
+++ b/lib/my-amazon-q-slack-bot-stack.ts
@@ -54,6 +54,7 @@ export class MyAmazonQSlackBotStack extends cdk.Stack {
         name: 'channel',
         type: AttributeType.STRING
       },
+      pointInTimeRecovery: true,
       timeToLiveAttribute: 'expireAt',
       removalPolicy: cdk.RemovalPolicy.DESTROY
     });
@@ -64,6 +65,7 @@ export class MyAmazonQSlackBotStack extends cdk.Stack {
         name: 'messageId',
         type: AttributeType.STRING
       },
+      pointInTimeRecovery: true,
       timeToLiveAttribute: 'expireAt',
       removalPolicy: cdk.RemovalPolicy.DESTROY
     });


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

This enables PITR on each of the DynamoDB tables.

I'm trying to run cdk-nag against this solution and it warning about the tables not having PITR enabled.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
