### PR TITLE
Fix random session expiration issue.

### DIFF
--- a/src/helpers/amazon-q/amazon-q-client.ts
+++ b/src/helpers/amazon-q/amazon-q-client.ts
@@ -17,24 +17,17 @@ import { Credentials } from 'aws-sdk';
 
 const logger = makeLogger('amazon-q-client');
 
-const amazonQClientBySlackUserId: { [key: string]: QBusinessClient } = {};
-
 export const getClient = (
   env: SlackEventsEnv,
   slackUserId: string,
   iamSessionCreds: Credentials
 ) => {
   logger.debug(`Initiating AmazonQ client with region ${env.AMAZON_Q_REGION}`);
-  if (amazonQClientBySlackUserId[slackUserId]) {
-    return amazonQClientBySlackUserId[slackUserId];
-  }
 
   const newClient = new QBusinessClient({
     credentials: iamSessionCreds,
     region: env.AMAZON_Q_REGION
   });
-
-  amazonQClientBySlackUserId[slackUserId] = newClient;
 
   return newClient;
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The changes removes any caching of Amazon Q Business Client per teams user. Even though credentials are refreshed, due to caching of Q Business
Client, the outdated credentials are used. This is not an issue if lambda doesn't run for more than 5 minutes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
